### PR TITLE
Add `enable_cookie_store` to http transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +347,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -948,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1070,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
@@ -1103,6 +1162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1183,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1367,6 +1448,8 @@ source = "git+https://github.com/seanmonstar/reqwest.git?rev=fa74a8b835b2f194253
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1589,6 +1672,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1842,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1948,6 +2075,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2546,6 +2679,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ mime = "0.3.17"
 pyo3 = { version = "0.28.0", features = ["bytes"] }
 reqwest = { version = "0.13.1", features = [
     "brotli",
+    "cookies",
     "gzip",
     "hickory-dns",
     "http2",

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -430,6 +430,7 @@ class HTTPTransport:
         enable_brotli: bool = True,
         enable_zstd: bool = True,
         use_system_dns: bool = False,
+        enable_cookie_store: bool = False,
         enable_otel: bool = True,
         meter_provider: MeterProvider | None = None,
         tracer_provider: TracerProvider | None = None,
@@ -463,6 +464,9 @@ class HTTPTransport:
                             asynchronous DNS resolver implemented in Rust, but it can have different
                             behavior from system DNS in certain environments. Try enabling this option if
                             you have any DNS resolution issues.
+            enable_cookie_store: Whether to enable automatic cookie storage and sending. When enabled,
+                          the transport will automatically store cookies from responses and send
+                          them with subsequent requests.
         """
 
     def __aenter__(self) -> Awaitable[HTTPTransport]:
@@ -864,6 +868,7 @@ class SyncHTTPTransport:
         enable_brotli: bool = True,
         enable_zstd: bool = True,
         use_system_dns: bool = False,
+        enable_cookie_store: bool = False,
         enable_otel: bool = True,
         meter_provider: MeterProvider | None = None,
         tracer_provider: TracerProvider | None = None,
@@ -897,6 +902,9 @@ class SyncHTTPTransport:
                             asynchronous DNS resolver implemented in Rust, but it can have different
                             behavior from system DNS in certain environments. Try enabling this option if
                             you have any DNS resolution issues.
+            enable_cookie_store: Whether to enable automatic cookie storage and sending. When enabled,
+                          the transport will automatically store cookies from responses and send
+                          them with subsequent requests.
         """
 
     def __enter__(self) -> SyncHTTPTransport:

--- a/src/asyncio/transport.rs
+++ b/src/asyncio/transport.rs
@@ -45,6 +45,7 @@ impl HttpTransport {
         enable_brotli = true,
         enable_zstd = true,
         use_system_dns = false,
+        enable_cookie_store = false,
         enable_otel = true,
         meter_provider = None,
         tracer_provider = None,
@@ -65,6 +66,7 @@ impl HttpTransport {
         enable_brotli: bool,
         enable_zstd: bool,
         use_system_dns: bool,
+        enable_cookie_store: bool,
         enable_otel: bool,
         meter_provider: Option<Bound<'_, PyAny>>,
         tracer_provider: Option<Bound<'_, PyAny>>,
@@ -84,6 +86,7 @@ impl HttpTransport {
             enable_brotli,
             enable_zstd,
             use_system_dns,
+            enable_cookie_store,
         })?;
         let constants = Constants::get(py)?;
         Ok(Self {

--- a/src/shared/transport.rs
+++ b/src/shared/transport.rs
@@ -26,6 +26,7 @@ pub(crate) struct ClientParams<'a> {
     pub(crate) enable_brotli: bool,
     pub(crate) enable_zstd: bool,
     pub(crate) use_system_dns: bool,
+    pub(crate) enable_cookie_store: bool,
 }
 
 pub(crate) fn new_reqwest_client(params: ClientParams) -> PyResult<(reqwest::Client, bool)> {
@@ -86,6 +87,7 @@ pub(crate) fn new_reqwest_client(params: ClientParams) -> PyResult<(reqwest::Cli
     builder = builder.brotli(params.enable_brotli);
     builder = builder.zstd(params.enable_zstd);
     builder = builder.hickory_dns(!params.use_system_dns);
+    builder = builder.cookie_store(params.enable_cookie_store);
 
     let client = if http3 {
         // Workaround https://github.com/seanmonstar/reqwest/issues/2910
@@ -118,6 +120,7 @@ pub(crate) fn get_default_reqwest_client(py: Python<'_>) -> reqwest::Client {
                 enable_brotli: true,
                 enable_zstd: true,
                 use_system_dns: false,
+                enable_cookie_store: false,
             })
             .unwrap();
             client

--- a/src/sync/transport.rs
+++ b/src/sync/transport.rs
@@ -50,6 +50,7 @@ impl SyncHttpTransport {
         enable_brotli = true,
         enable_zstd = true,
         use_system_dns = false,
+        enable_cookie_store = false,
         enable_otel = true,
         meter_provider = None,
         tracer_provider = None,
@@ -70,6 +71,7 @@ impl SyncHttpTransport {
         enable_brotli: bool,
         enable_zstd: bool,
         use_system_dns: bool,
+        enable_cookie_store: bool,
         enable_otel: bool,
         meter_provider: Option<Bound<'_, PyAny>>,
         tracer_provider: Option<Bound<'_, PyAny>>,
@@ -89,6 +91,7 @@ impl SyncHttpTransport {
             enable_brotli,
             enable_zstd,
             use_system_dns,
+            enable_cookie_store,
         })?;
         let constants = Constants::get(py)?;
         Ok(Self {

--- a/tests/apps/asgi/kitchensink.py
+++ b/tests/apps/asgi/kitchensink.py
@@ -134,6 +134,36 @@ async def _read_all(
     await send({"type": "http.response.body", "body": bytes(buf), "more_body": False})
 
 
+async def _set_cookie(
+    _scope: HTTPScope, _receive: ASGIReceiveCallable, send: ASGISendCallable
+) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"set-cookie", b"testcookie=hello")],
+            "trailers": False,
+        }
+    )
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+async def _get_cookie(
+    scope: HTTPScope, _receive: ASGIReceiveCallable, send: ASGISendCallable
+) -> None:
+    headers_dict = dict(scope["headers"])
+    cookie = headers_dict.get(b"cookie", b"")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [],
+            "trailers": False,
+        }
+    )
+    await send({"type": "http.response.body", "body": cookie, "more_body": False})
+
+
 async def app(
     scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 ) -> None:
@@ -147,6 +177,10 @@ async def app(
             await _content_encoding(scope, receive, send)
         case "/read_all":
             await _read_all(scope, receive, send)
+        case "/set-cookie":
+            await _set_cookie(scope, receive, send)
+        case "/get-cookie":
+            await _get_cookie(scope, receive, send)
         case _:
             await send(
                 {

--- a/tests/apps/wsgi/kitchensink.py
+++ b/tests/apps/wsgi/kitchensink.py
@@ -89,6 +89,21 @@ def _read_all(
     yield bytes(request_body)
 
 
+def _set_cookie(
+    _environ: WSGIEnvironment, start_response: StartResponse
+) -> Iterable[bytes]:
+    start_response("200 OK", [("set-cookie", "testcookie=hello")])
+    return [b""]
+
+
+def _get_cookie(
+    environ: WSGIEnvironment, start_response: StartResponse
+) -> Iterable[bytes]:
+    cookie = environ.get("HTTP_COOKIE", "")
+    start_response("200 OK", [])
+    return [cookie.encode()]
+
+
 def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
     path = cast("str", environ["PATH_INFO"]).encode("latin-1").decode("utf-8")
     match path:
@@ -100,6 +115,10 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
             return _content_encoding(environ, start_response)
         case "/read_all":
             return _read_all(environ, start_response)
+        case "/set-cookie":
+            return _set_cookie(environ, start_response)
+        case "/get-cookie":
+            return _get_cookie(environ, start_response)
         case "/no_start":
             return []
         case _:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -154,3 +154,39 @@ async def test_sync_transport_options(url: str) -> None:
 
     with pytest.raises(RuntimeError, match="already closed transport"):
         SyncClient(transport).get(url)
+
+
+@pytest.mark.asyncio
+async def test_cookie_store(url: str) -> None:
+    async with HTTPTransport(enable_cookie_store=True) as transport:
+        client = Client(transport)
+        await client.get(f"{url}/set-cookie")
+        res = await client.get(f"{url}/get-cookie")
+        assert res.content == b"testcookie=hello"
+
+
+@pytest.mark.asyncio
+async def test_cookie_store_disabled(url: str) -> None:
+    async with HTTPTransport() as transport:
+        client = Client(transport)
+        await client.get(f"{url}/set-cookie")
+        res = await client.get(f"{url}/get-cookie")
+        assert res.content == b""
+
+
+@pytest.mark.asyncio
+async def test_cookie_store_sync(url: str) -> None:
+    with SyncHTTPTransport(enable_cookie_store=True) as transport:
+        client = SyncClient(transport)
+        await asyncio.to_thread(client.get, f"{url}/set-cookie")
+        res = await asyncio.to_thread(client.get, f"{url}/get-cookie")
+        assert res.content == b"testcookie=hello"
+
+
+@pytest.mark.asyncio
+async def test_cookie_store_sync_disabled(url: str) -> None:
+    with SyncHTTPTransport() as transport:
+        client = SyncClient(transport)
+        await asyncio.to_thread(client.get, f"{url}/set-cookie")
+        res = await asyncio.to_thread(client.get, f"{url}/get-cookie")
+        assert res.content == b""


### PR DESCRIPTION
This allows you to preserve cookies in between requests, similar to `aiohttp.ClientSession` behavior with `aiohttp.CookieJar`. Just relies on the underlying reqwest implementation under the hood, like most features in this library.

Also added tests for this. Just a basic common implementation of the feature for 90% of use cases. Didn't turn it on by default for backward compatibility.

Resolves #131