### PR TITLE
Add retries option to transports for retrying connect errors

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,3 +157,32 @@ setting. Connect and read timeout cannot be configured per-call.
     ```python
     response = client.get("https://pyqwest.dev", timeout=2.0)
     ```
+
+### Retries
+
+The transport can be configured to retry requests that fail to connect, for example because
+the server is temporarily unavailable or a connection could not be established within the
+connect timeout. Because a connection failure happens before any data is sent, it is safe to
+retry requests with any HTTP method. The first retry is immediate, and subsequent retries
+back off exponentially, starting at 0.5s. Requests with a streaming body are not retried.
+
+=== "async"
+
+    ```python
+    async with HTTPTransport(retries=3) as transport:
+        client = Client(transport)
+        application = MyApplication(client)
+    ```
+
+=== "sync"
+
+    ```python
+    with SyncHTTPTransport(retries=3) as transport:
+        client = SyncClient(transport)
+        application = MyApplication(client)
+    ```
+
+Errors that occur after connecting, such as error status codes or broken response streams,
+are not retried by the transport. Application-level retries can be configured using
+`pyqwest.middleware.retry.RetryTransport` and `pyqwest.middleware.retry.SyncRetryTransport`,
+which wrap any transport and also retry requests based on response status codes.

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -458,6 +458,7 @@ class HTTPTransport:
         pool_idle_timeout: float | None = 90.0,
         pool_max_idle_per_host: int | None = None,
         tcp_keepalive_interval: float | None = 30.0,
+        retries: int = 0,
         enable_gzip: bool = True,
         enable_brotli: bool = True,
         enable_zstd: bool = True,
@@ -491,6 +492,10 @@ class HTTPTransport:
             pool_max_idle_per_host: Maximum number of idle connections to keep in the pool per host.
                                     Defaults to 2.
             tcp_keepalive_interval: Interval for TCP keepalive probes in seconds.
+            retries: Maximum number of times to retry a request that failed to connect
+                     before giving up. Only errors establishing a connection, before any
+                     data is sent to the server, are retried, with an exponential backoff
+                     between attempts. Requests with a streaming body are not retried.
             enable_gzip: Whether to enable gzip decompression for responses.
             enable_brotli: Whether to enable brotli decompression for responses.
             enable_zstd: Whether to enable zstd decompression for responses.
@@ -932,6 +937,7 @@ class SyncHTTPTransport:
         pool_idle_timeout: float | None = 90.0,
         pool_max_idle_per_host: int | None = None,
         tcp_keepalive_interval: float | None = 30.0,
+        retries: int = 0,
         enable_gzip: bool = True,
         enable_brotli: bool = True,
         enable_zstd: bool = True,
@@ -965,6 +971,10 @@ class SyncHTTPTransport:
             pool_max_idle_per_host: Maximum number of idle connections to keep in the pool per host.
                                     Defaults to 2.
             tcp_keepalive_interval: Interval for TCP keepalive probes in seconds.
+            retries: Maximum number of times to retry a request that failed to connect
+                     before giving up. Only errors establishing a connection, before any
+                     data is sent to the server, are retried, with an exponential backoff
+                     between attempts. Requests with a streaming body are not retried.
             enable_gzip: Whether to enable gzip decompression for responses.
             enable_brotli: Whether to enable brotli decompression for responses.
             enable_zstd: Whether to enable zstd decompression for responses.

--- a/src/asyncio/transport.rs
+++ b/src/asyncio/transport.rs
@@ -13,7 +13,9 @@ use crate::common::httpversion::HTTPVersion;
 use crate::pyerrors;
 use crate::shared::constants::Constants;
 use crate::shared::otel::{Instrumentation, Operation};
-use crate::shared::transport::{get_default_reqwest_client, new_reqwest_client, ClientParams};
+use crate::shared::transport::{
+    execute_with_retries, get_default_reqwest_client, new_reqwest_client, ClientParams,
+};
 
 #[pyclass(module = "_pyqwest", name = "HTTPTransport", frozen, from_py_object)]
 #[derive(Clone)]
@@ -21,6 +23,7 @@ pub struct HttpTransport {
     client: Arc<ArcSwapOption<reqwest::Client>>,
     http3: bool,
     close: bool,
+    retries: u32,
 
     instrumentation: Instrumentation,
     constants: Constants,
@@ -42,6 +45,7 @@ impl HttpTransport {
         pool_idle_timeout = 90.0,
         pool_max_idle_per_host = None,
         tcp_keepalive_interval = 30.0,
+        retries = 0,
         enable_gzip = true,
         enable_brotli = true,
         enable_zstd = true,
@@ -64,6 +68,7 @@ impl HttpTransport {
         pool_idle_timeout: Option<f64>,
         pool_max_idle_per_host: Option<usize>,
         tcp_keepalive_interval: Option<f64>,
+        retries: u32,
         enable_gzip: bool,
         enable_brotli: bool,
         enable_zstd: bool,
@@ -96,6 +101,7 @@ impl HttpTransport {
             client: Arc::new(ArcSwapOption::from_pointee(client)),
             http3,
             close: true,
+            retries,
             instrumentation: Instrumentation::new(
                 py,
                 enable_otel,
@@ -160,9 +166,9 @@ impl HttpTransport {
             let client = client.clone();
             let operation = operation.clone();
             let request_iter_task = request_iter_task.clone();
+            let retries = self.retries;
             async move {
-                let res = client
-                    .execute(request_rs)
+                let res = execute_with_retries(&client, request_rs, retries)
                     .await
                     .map_err(|e| pyerrors::from_reqwest(&e, "Request failed"))?;
                 operation.fill_response(&res);
@@ -201,9 +207,9 @@ impl HttpTransport {
         let fut = future_into_py(py, {
             let client = client.clone();
             let operation = operation.clone();
+            let retries = self.retries;
             async move {
-                let res = client
-                    .execute(request_rs)
+                let res = execute_with_retries(&client, request_rs, retries)
                     .await
                     .map_err(|e| pyerrors::from_reqwest(&e, "Request failed"))?;
                 operation.fill_response(&res);
@@ -230,6 +236,7 @@ impl HttpTransport {
             client: Arc::new(ArcSwapOption::from_pointee(get_default_reqwest_client(py))),
             http3: false,
             close: false,
+            retries: 0,
             instrumentation: Instrumentation::new(py, true, None, None, &constants)?,
             constants,
         })

--- a/src/shared/transport.rs
+++ b/src/shared/transport.rs
@@ -109,6 +109,45 @@ pub(crate) fn new_reqwest_client(params: ClientParams) -> PyResult<(reqwest::Cli
     Ok((client, http3))
 }
 
+// The same backoff schedule as HTTPX - the first retry is immediate and
+// subsequent retries back off exponentially starting from this factor,
+// i.e. 0s, 0.5s, 1s, 2s, ...
+const RETRY_BACKOFF_FACTOR: f64 = 0.5;
+
+pub(crate) async fn execute_with_retries(
+    client: &reqwest::Client,
+    mut request: reqwest::Request,
+    retries: u32,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let mut attempt = 0u32;
+    loop {
+        // execute consumes the request, so clone before it if we may still retry.
+        // Requests with a streaming body cannot be cloned and are not retried.
+        let retry_request = if attempt < retries {
+            request.try_clone()
+        } else {
+            None
+        };
+        let err = match client.execute(request).await {
+            Ok(res) => return Ok(res),
+            Err(err) => err,
+        };
+        let Some(retry) = retry_request else {
+            return Err(err);
+        };
+        if !err.is_connect() {
+            return Err(err);
+        }
+        if attempt > 0 {
+            let exp = i32::try_from(attempt - 1).unwrap_or(i32::MAX);
+            let backoff = RETRY_BACKOFF_FACTOR * 2f64.powi(exp);
+            tokio::time::sleep(Duration::from_secs_f64(backoff)).await;
+        }
+        attempt += 1;
+        request = retry;
+    }
+}
+
 pub(crate) fn get_default_reqwest_client(py: Python<'_>) -> reqwest::Client {
     DEFAULT_REQWEST_CLIENT
         .get_or_init(py, || {

--- a/src/sync/transport.rs
+++ b/src/sync/transport.rs
@@ -11,7 +11,9 @@ use crate::common::httpversion::HTTPVersion;
 use crate::pyerrors;
 use crate::shared::constants::Constants;
 use crate::shared::otel::{Instrumentation, Operation};
-use crate::shared::transport::{get_default_reqwest_client, new_reqwest_client, ClientParams};
+use crate::shared::transport::{
+    execute_with_retries, get_default_reqwest_client, new_reqwest_client, ClientParams,
+};
 use crate::sync::request::SyncRequest;
 use crate::sync::response::{close_request_iter, RequestIterHandle, SyncResponse};
 
@@ -26,6 +28,7 @@ pub struct SyncHttpTransport {
     client: Arc<ArcSwapOption<reqwest::Client>>,
     http3: bool,
     close: bool,
+    retries: u32,
 
     instrumentation: Instrumentation,
     constants: Constants,
@@ -47,6 +50,7 @@ impl SyncHttpTransport {
         pool_idle_timeout = 90.0,
         pool_max_idle_per_host = None,
         tcp_keepalive_interval = 30.0,
+        retries = 0,
         enable_gzip = true,
         enable_brotli = true,
         enable_zstd = true,
@@ -69,6 +73,7 @@ impl SyncHttpTransport {
         pool_idle_timeout: Option<f64>,
         pool_max_idle_per_host: Option<usize>,
         tcp_keepalive_interval: Option<f64>,
+        retries: u32,
         enable_gzip: bool,
         enable_brotli: bool,
         enable_zstd: bool,
@@ -101,6 +106,7 @@ impl SyncHttpTransport {
             client: Arc::new(ArcSwapOption::from_pointee(client)),
             http3,
             close: true,
+            retries,
             instrumentation: Instrumentation::new(
                 py,
                 enable_otel,
@@ -185,8 +191,9 @@ impl SyncHttpTransport {
         operation.inject(py, &mut request_rs)?;
         let client = client.clone();
         let operation = operation.clone();
+        let retries = self.retries;
         get_runtime().spawn(async move {
-            match client.execute(request_rs).await {
+            match execute_with_retries(&client, request_rs, retries).await {
                 Ok(res) => {
                     operation.fill_response(&res);
                     response.fill(res).await;
@@ -211,6 +218,7 @@ impl SyncHttpTransport {
             client: Arc::new(ArcSwapOption::from_pointee(get_default_reqwest_client(py))),
             http3: false,
             close: false,
+            retries: 0,
             instrumentation: Instrumentation::new(py, true, None, None, &constants)?,
             constants,
         })

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -102,8 +102,10 @@ async def test_async_streaming_request_not_retried() -> None:
             await transport.execute(
                 Request("POST", f"http://127.0.0.1:{port}/", content=content())
             )
-        # Retrying 5 times would back off for a total of 7.5s.
-        assert time.monotonic() - start < 2
+        # Retrying 5 times would back off for a total of 7.5s. A single
+        # refused connect can itself take ~2s on Windows, which retransmits
+        # before reporting the failure, so leave headroom below that.
+        assert time.monotonic() - start < 5
 
 
 @pytest.mark.asyncio

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyqwest import HTTPTransport, Request, SyncHTTPTransport, SyncRequest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def serve_one_request(port: int, delay: float) -> None:
+    """Starts a server on the port after a delay and serves one request.
+
+    Until the server starts, connection attempts to the port are refused,
+    allowing tests to exercise connect retries.
+    """
+    time.sleep(delay)
+    with socket.socket() as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", port))
+        sock.listen()
+        conn, _ = sock.accept()
+        with conn:
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            conn.sendall(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+
+
+@pytest.mark.asyncio
+async def test_async_retries_until_connect_succeeds() -> None:
+    port = free_port()
+    server = threading.Thread(target=serve_one_request, args=(port, 0.2))
+    server.start()
+    try:
+        async with HTTPTransport(retries=3) as transport:
+            res = await transport.execute(Request("GET", f"http://127.0.0.1:{port}/"))
+            assert res.status == 200
+            await res.aclose()
+    finally:
+        server.join()
+
+
+def test_sync_retries_until_connect_succeeds() -> None:
+    port = free_port()
+    server = threading.Thread(target=serve_one_request, args=(port, 0.2))
+    server.start()
+    try:
+        with SyncHTTPTransport(retries=3) as transport:
+            res = transport.execute_sync(
+                SyncRequest("GET", f"http://127.0.0.1:{port}/")
+            )
+            assert res.status == 200
+            res.close()
+    finally:
+        server.join()
+
+
+@pytest.mark.asyncio
+async def test_async_retries_exhausted() -> None:
+    port = free_port()
+    async with HTTPTransport(retries=2) as transport:
+        start = time.monotonic()
+        with pytest.raises(ConnectionError):
+            await transport.execute(Request("GET", f"http://127.0.0.1:{port}/"))
+        # The second retry backs off for 0.5s.
+        assert time.monotonic() - start >= 0.4
+
+
+def test_sync_retries_exhausted() -> None:
+    port = free_port()
+    with SyncHTTPTransport(retries=2) as transport:
+        start = time.monotonic()
+        with pytest.raises(ConnectionError):
+            transport.execute_sync(SyncRequest("GET", f"http://127.0.0.1:{port}/"))
+        assert time.monotonic() - start >= 0.4
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_request_not_retried() -> None:
+    async def content() -> AsyncIterator[bytes]:
+        yield b"hello"
+
+    port = free_port()
+    async with HTTPTransport(retries=5) as transport:
+        start = time.monotonic()
+        with pytest.raises(ConnectionError):
+            await transport.execute(
+                Request("POST", f"http://127.0.0.1:{port}/", content=content())
+            )
+        # Retrying 5 times would back off for a total of 7.5s.
+        assert time.monotonic() - start < 2
+
+
+@pytest.mark.asyncio
+async def test_negative_retries() -> None:
+    with pytest.raises(OverflowError):
+        HTTPTransport(retries=-1)
+    with pytest.raises(OverflowError):
+        SyncHTTPTransport(retries=-1)


### PR DESCRIPTION
Adds an HTTPX-style `retries` option to `HTTPTransport` and `SyncHTTPTransport` that retries requests failing to establish a connection (refused connections, DNS failures, connect timeouts), which is safe for any HTTP method since no data has reached the server. Retries follow HTTPX's backoff schedule: the first retry is immediate and subsequent retries back off exponentially starting at 0.5s. Requests with a streaming body are not retried since they cannot be cloned; the default remains `retries=0`. Includes type stubs, a new "Retries" section in the usage docs cross-referencing the response-level retry middleware, and socket-based tests covering retry-until-success, exhaustion, and streaming-body behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)