### PR TITLE
Add per-request timeout to async client

### DIFF
--- a/pyqwest/_coro.py
+++ b/pyqwest/_coro.py
@@ -21,10 +21,6 @@ class Client:
 
     A client is a lightweight wrapper around a Transport, providing convenience methods
     for common HTTP operations with buffering.
-
-    The asynchronous client does not expose per-request timeouts on its methods.
-    Use `asyncio.wait_for` or similar to enforce timeouts per-requests or initialize
-    `HTTPTransport` with a default timeout.
     """
 
     _client: NativeClient
@@ -43,6 +39,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a GET HTTP request.
@@ -50,6 +47,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -58,7 +56,9 @@ class Client:
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
-        return await self._client.get(url, headers=headers, params=params)
+        return await self._client.get(
+            url, headers=headers, timeout=timeout, params=params
+        )
 
     async def post(
         self,
@@ -66,6 +66,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a POST HTTP request.
@@ -74,6 +75,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -83,7 +85,7 @@ class Client:
             WriteError: If an error occurs writing the request.
         """
         return await self._client.post(
-            url, headers=headers, content=content, params=params
+            url, headers=headers, content=content, timeout=timeout, params=params
         )
 
     async def delete(
@@ -91,6 +93,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a DELETE HTTP request.
@@ -98,6 +101,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -106,13 +110,16 @@ class Client:
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
-        return await self._client.delete(url, headers=headers, params=params)
+        return await self._client.delete(
+            url, headers=headers, timeout=timeout, params=params
+        )
 
     async def head(
         self,
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a HEAD HTTP request.
@@ -120,6 +127,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -128,13 +136,16 @@ class Client:
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
-        return await self._client.head(url, headers=headers, params=params)
+        return await self._client.head(
+            url, headers=headers, timeout=timeout, params=params
+        )
 
     async def options(
         self,
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a OPTIONS HTTP request.
@@ -142,6 +153,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -150,7 +162,9 @@ class Client:
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
-        return await self._client.options(url, headers=headers, params=params)
+        return await self._client.options(
+            url, headers=headers, timeout=timeout, params=params
+        )
 
     async def patch(
         self,
@@ -158,6 +172,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a PATCH HTTP request.
@@ -166,6 +181,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -175,7 +191,7 @@ class Client:
             WriteError: If an error occurs writing the request.
         """
         return await self._client.patch(
-            url, headers=headers, content=content, params=params
+            url, headers=headers, content=content, timeout=timeout, params=params
         )
 
     async def put(
@@ -184,6 +200,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes a PUT HTTP request.
@@ -192,6 +209,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -201,7 +219,7 @@ class Client:
             WriteError: If an error occurs writing the request.
         """
         return await self._client.put(
-            url, headers=headers, content=content, params=params
+            url, headers=headers, content=content, timeout=timeout, params=params
         )
 
     async def execute(
@@ -211,6 +229,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> FullResponse:
         """Executes an HTTP request, returning the full buffered response.
@@ -220,6 +239,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -229,7 +249,12 @@ class Client:
             WriteError: If an error occurs writing the request.
         """
         return await self._client.execute(
-            method, url, headers=headers, content=content, params=params
+            method,
+            url,
+            headers=headers,
+            content=content,
+            timeout=timeout,
+            params=params,
         )
 
     @asynccontextmanager
@@ -240,6 +265,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> AsyncIterator[Response]:
         """Executes an HTTP request, allowing the response content to be streamed.
@@ -249,6 +275,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -258,7 +285,12 @@ class Client:
             WriteError: If an error occurs writing the request.
         """
         response = await self._client.stream(
-            method, url, headers=headers, content=content, params=params
+            method,
+            url,
+            headers=headers,
+            content=content,
+            timeout=timeout,
+            params=params,
         )
         async with response:
             yield response

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -217,9 +217,6 @@ class Client:
     def __init__(self, transport: Transport | None = None) -> None:
         """Creates a new asynchronous HTTP client.
 
-        The asynchronous client does not expose per-request timeouts on its methods.
-        Use `asyncio.wait_for` or similar to enforce timeouts on requests.
-
         Args:
             transport: The transport to use for requests. If None, the shared default
                        transport will be used.
@@ -230,6 +227,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a GET HTTP request.
@@ -237,6 +235,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -252,6 +251,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a POST HTTP request.
@@ -260,6 +260,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -274,6 +275,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a DELETE HTTP request.
@@ -281,6 +283,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
         Raises:
             ConnectionError: If the connection fails.
@@ -294,6 +297,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a HEAD HTTP request.
@@ -301,6 +305,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -315,6 +320,7 @@ class Client:
         url: str,
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a OPTIONS HTTP request.
@@ -322,6 +328,7 @@ class Client:
         Args:
             url: The unencoded request URL.
             headers: The request headers.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -337,6 +344,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a PATCH HTTP request.
@@ -345,6 +353,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -360,6 +369,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes a PUT HTTP request.
@@ -368,6 +378,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -384,6 +395,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[FullResponse]:
         """Executes an HTTP request, returning the full buffered response.
@@ -393,6 +405,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -409,6 +422,7 @@ class Client:
         headers: Headers | Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> Awaitable[Response]:
         """Executes an HTTP request, allowing the response content to be streamed.
@@ -418,6 +432,7 @@ class Client:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds.
             params: Query parameters to append to the URL. None values will be treated as key-only.
 
         Raises:
@@ -559,6 +574,7 @@ class Request:
         headers: Headers | None = None,
         content: _RequestContent | None = None,
         *,
+        timeout: float | None = None,
         params: _QueryParams | None = None,
     ) -> None:
         """Creates a new Request object.
@@ -568,6 +584,9 @@ class Request:
             url: The unencoded request URL.
             headers: The request headers.
             content: The request content. A Python dictionary will be converted to JSON.
+            timeout: The timeout for the request in seconds. The deadline is computed
+                     when the request is created, so time spent before executing the
+                     request counts against the timeout.
             params: Query parameters to append to the URL. None values will be treated as key-only.
         """
 
@@ -586,6 +605,12 @@ class Request:
     @property
     def content(self) -> bytes | AsyncIterator[bytes]:
         """Returns an async iterator over the request content."""
+
+    @property
+    def timeout(self) -> float | None:
+        """Returns the time remaining until the request's deadline in seconds,
+        or None if no timeout was set.
+        """
 
     @property
     def _json(self) -> bool: ...

--- a/pyqwest/middleware/retry/_async.py
+++ b/pyqwest/middleware/retry/_async.py
@@ -86,6 +86,7 @@ class RetryTransport(Transport):
                     url=request.url,
                     headers=request.headers,
                     content=initial_request_content,
+                    timeout=request.timeout,
                 )
             )
         except Exception as e:
@@ -127,6 +128,7 @@ class RetryTransport(Transport):
                         url=request.url,
                         headers=request.headers,
                         content=content,
+                        timeout=request.timeout,
                     )
                 )
             except Exception as e:

--- a/pyqwest/testing/_asgi.py
+++ b/pyqwest/testing/_asgi.py
@@ -83,6 +83,11 @@ class ASGITransport(Transport):
         self._app_exception = None
 
     async def execute(self, request: Request) -> Response:
+        timeout = request.timeout
+        deadline = None
+        if timeout is not None:
+            deadline = asyncio.get_running_loop().time() + timeout
+
         parsed_url = urlparse(request.url)
         raw_path = parsed_url.path or "/"
         path = unquote(raw_path)
@@ -182,7 +187,21 @@ class ASGITransport(Transport):
                 send_queue.put_nowait(e)
 
         app_task = asyncio.create_task(run_app())
-        message = await send_queue.get()
+        if deadline is not None:
+            time_left = deadline - asyncio.get_running_loop().time()
+            try:
+                message = await asyncio.wait_for(send_queue.get(), max(time_left, 0))
+            except (TimeoutError, asyncio.TimeoutError) as e:
+                request_task.cancel()
+                app_task.cancel()
+                with contextlib.suppress(BaseException):
+                    await app_task
+                with contextlib.suppress(BaseException):
+                    await request_task
+                msg = "Application did not start response before timeout"
+                raise TimeoutError(msg) from e
+        else:
+            message = await send_queue.get()
         if isinstance(message, Exception):
             request_task.cancel()
             with contextlib.suppress(BaseException):
@@ -218,6 +237,7 @@ class ASGITransport(Transport):
             request_task,
             trailers,
             app_task,
+            deadline,
             decompressor,
             read_trailers=message.get("trailers", False),
         )
@@ -320,6 +340,7 @@ class ResponseContent(AsyncIterator[bytes]):
         request_task: asyncio.Task[None],
         trailers: Headers | None,
         task: asyncio.Task[None],
+        deadline: float | None,
         decompressor: Decompressor,
         *,
         read_trailers: bool,
@@ -328,6 +349,7 @@ class ResponseContent(AsyncIterator[bytes]):
         self._request_task = request_task
         self._trailers = trailers
         self._task = task
+        self._deadline = deadline
         self._decompressor = decompressor
         self._read_trailers = read_trailers
 
@@ -345,7 +367,17 @@ class ResponseContent(AsyncIterator[bytes]):
         while True:
             self._read_pending = True
             try:
-                message = await self._send_queue.get()
+                if self._deadline is not None:
+                    time_left = self._deadline - asyncio.get_running_loop().time()
+                    try:
+                        message = await asyncio.wait_for(
+                            self._send_queue.get(), max(time_left, 0)
+                        )
+                    except (TimeoutError, asyncio.TimeoutError):
+                        msg = "Response read timed out"
+                        message = TimeoutError(msg)
+                else:
+                    message = await self._send_queue.get()
             finally:
                 self._read_pending = False
             if isinstance(message, Exception):

--- a/src/asyncio/client.rs
+++ b/src/asyncio/client.rs
@@ -38,87 +38,94 @@ impl Client {
         })
     }
 
-    #[pyo3(signature = (url, headers=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, *, timeout=None, params=None))]
     fn get<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "GET", url, headers, None, params)
+        self.execute(py, "GET", url, headers, None, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, content=None, *, timeout=None, params=None))]
     fn post<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "POST", url, headers, content, params)
+        self.execute(py, "POST", url, headers, content, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, *, timeout=None, params=None))]
     fn delete<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "DELETE", url, headers, None, params)
+        self.execute(py, "DELETE", url, headers, None, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, *, timeout=None, params=None))]
     fn head<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "HEAD", url, headers, None, params)
+        self.execute(py, "HEAD", url, headers, None, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, *, timeout=None, params=None))]
     fn options<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "OPTIONS", url, headers, None, params)
+        self.execute(py, "OPTIONS", url, headers, None, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, content=None, *, timeout=None, params=None))]
     fn patch<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "PATCH", url, headers, content, params)
+        self.execute(py, "PATCH", url, headers, content, timeout, params)
     }
 
-    #[pyo3(signature = (url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (url, headers=None, content=None, *, timeout=None, params=None))]
     fn put<'py>(
         &self,
         py: Python<'py>,
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.execute(py, "PUT", url, headers, content, params)
+        self.execute(py, "PUT", url, headers, content, timeout, params)
     }
 
-    #[pyo3(signature = (method, url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (method, url, headers=None, content=None, *, timeout=None, params=None))]
     fn execute<'py>(
         &self,
         py: Python<'py>,
@@ -126,6 +133,7 @@ impl Client {
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let headers = if let Some(headers) = headers {
@@ -143,6 +151,7 @@ impl Client {
             url,
             headers,
             content,
+            timeout,
             params,
             self.constants.clone(),
         )?;
@@ -156,7 +165,7 @@ impl Client {
         }
     }
 
-    #[pyo3(signature = (method, url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (method, url, headers=None, content=None, *, timeout=None, params=None))]
     fn stream<'py>(
         &self,
         py: Python<'py>,
@@ -164,6 +173,7 @@ impl Client {
         url: &str,
         headers: Option<Bound<'py, PyAny>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let headers = if let Some(headers) = headers {
@@ -175,7 +185,16 @@ impl Client {
         } else {
             None
         };
-        let request = Request::py_new(py, method, url, headers, content, params)?;
+        let request = Request::new(
+            py,
+            method,
+            url,
+            headers,
+            content,
+            timeout,
+            params,
+            self.constants.clone(),
+        )?;
         match &self.transport {
             Transport::Http(transport) => transport.do_stream(py, &request),
             Transport::Custom(transport) => transport

--- a/src/asyncio/request.rs
+++ b/src/asyncio/request.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
@@ -18,6 +19,7 @@ use crate::{
     shared::{
         constants::Constants,
         request::{maybe_encode_json_content, RequestHead, RequestStreamResult},
+        validation::validate_timeout,
     },
 };
 
@@ -32,13 +34,14 @@ pub struct Request {
 #[pymethods]
 impl Request {
     #[new]
-    #[pyo3(signature = (method, url, headers=None, content=None, *, params=None))]
+    #[pyo3(signature = (method, url, headers=None, content=None, *, timeout=None, params=None))]
     pub(crate) fn py_new<'py>(
         py: Python<'py>,
         method: &str,
         url: &str,
         headers: Option<Bound<'py, Headers>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         Request::new(
@@ -47,6 +50,7 @@ impl Request {
             url,
             headers,
             content,
+            timeout,
             params,
             Constants::get(py)?,
         )
@@ -77,6 +81,13 @@ impl Request {
     }
 
     #[getter]
+    fn timeout(&self) -> Option<f64> {
+        self.head
+            .deadline()
+            .map(|d| d.saturating_duration_since(Instant::now()).as_secs_f64())
+    }
+
+    #[getter]
     fn _json(&self) -> bool {
         self.head.json()
     }
@@ -89,6 +100,7 @@ impl Request {
         url: &str,
         headers: Option<Bound<'py, Headers>>,
         content: Option<Bound<'py, PyAny>>,
+        timeout: Option<f64>,
         params: Option<Bound<'py, PyAny>>,
         constants: Constants,
     ) -> PyResult<Self> {
@@ -103,8 +115,10 @@ impl Request {
             Some(content) => Some(Content::from_py(&content, &constants)?),
             None => None,
         };
+        let deadline = validate_timeout(timeout)?
+            .map(|timeout| Instant::now() + Duration::from_secs_f64(timeout));
         Ok(Self {
-            head: RequestHead::new(method, url, headers, params, json)?,
+            head: RequestHead::new(method, url, headers, params, json, deadline)?,
             content,
             constants,
         })

--- a/src/shared/request.rs
+++ b/src/shared/request.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Instant;
 
 use http::HeaderValue;
 use pyo3::sync::MutexExt as _;
@@ -20,6 +21,8 @@ pub(crate) struct RequestHead {
     headers: Py<Headers>,
     /// Whether to append JSON content type header automatically.
     json: bool,
+    /// Deadline for the request, if a per-request timeout was set.
+    deadline: Option<Instant>,
 }
 
 impl RequestHead {
@@ -29,6 +32,7 @@ impl RequestHead {
         headers: Py<Headers>,
         params: Option<Bound<'_, PyAny>>,
         json: bool,
+        deadline: Option<Instant>,
     ) -> PyResult<Self> {
         let method = http::Method::try_from(method)
             .map_err(|e| PyValueError::new_err(format!("Invalid HTTP method: {e}")))?;
@@ -54,6 +58,7 @@ impl RequestHead {
             url,
             headers,
             json,
+            deadline,
         })
     }
 
@@ -70,7 +75,9 @@ impl RequestHead {
             req.headers_mut()
                 .insert(http::header::CONTENT_TYPE, CONTENT_TYPE_JSON);
         }
-        if let Some(timeout) = get_timeout(py)? {
+        if let Some(deadline) = self.deadline {
+            *req.timeout_mut() = Some(deadline.saturating_duration_since(Instant::now()));
+        } else if let Some(timeout) = get_timeout(py)? {
             *req.timeout_mut() = Some(timeout);
         }
         Ok(req)
@@ -106,6 +113,10 @@ impl RequestHead {
 
     pub(crate) fn json(&self) -> bool {
         self.json
+    }
+
+    pub(crate) fn deadline(&self) -> Option<Instant> {
+        self.deadline
     }
 }
 

--- a/src/sync/request.rs
+++ b/src/sync/request.rs
@@ -102,7 +102,7 @@ impl SyncRequest {
             None => None,
         };
         Ok(Self {
-            head: RequestHead::new(method, url, headers, params, json)?,
+            head: RequestHead::new(method, url, headers, params, json, None)?,
             content,
             constants: constants.clone(),
         })

--- a/src/sync/timeout.rs
+++ b/src/sync/timeout.rs
@@ -25,7 +25,7 @@ pub(crate) fn get_timeout(py: Python<'_>) -> PyResult<Option<Duration>> {
         .call1(py, (py.None(),))?
         .extract(py)?;
 
-    Ok(deadline.map(|d| d.get().0 - Instant::now()))
+    Ok(deadline.map(|d| d.get().0.saturating_duration_since(Instant::now())))
 }
 
 #[pyclass(module = "_pyqwest", frozen)]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,6 +24,8 @@ from ._util import SyncRequestBody
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
+    from pyqwest import HTTPTransport
+
 
 pytestmark = [
     pytest.mark.parametrize("http_scheme", ["http", "https"], indirect=True),
@@ -793,3 +795,27 @@ async def test_nan_timeout(sync_client: SyncClient, url: str) -> None:
     url = f"{url}/echo"
     with pytest.raises(ValueError, match="Timeout must be non-negative"):
         await asyncio.to_thread(sync_client.get, url, timeout=float("nan"))
+
+
+@pytest.mark.asyncio
+async def test_negative_timeout_async(async_transport: HTTPTransport, url: str) -> None:
+    client = Client(async_transport)
+    url = f"{url}/echo"
+    with pytest.raises(ValueError, match="Timeout must be non-negative"):
+        await client.get(url, timeout=-5.0)
+
+
+@pytest.mark.asyncio
+async def test_infinite_timeout_async(async_transport: HTTPTransport, url: str) -> None:
+    client = Client(async_transport)
+    url = f"{url}/echo"
+    with pytest.raises(ValueError, match="Timeout must be non-negative"):
+        await client.get(url, timeout=float("inf"))
+
+
+@pytest.mark.asyncio
+async def test_nan_timeout_async(async_transport: HTTPTransport, url: str) -> None:
+    client = Client(async_transport)
+    url = f"{url}/echo"
+    with pytest.raises(ValueError, match="Timeout must be non-negative"):
+        await client.get(url, timeout=float("nan"))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import socket
-import sys
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -39,9 +38,6 @@ def sync_request_body(queue: Queue) -> Iterator[bytes]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    sys.version_info < (3, 11), reason="asyncio.timeout requires Python 3.11+"
-)
 async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
     method = "POST"
     url = f"{url}/echo"
@@ -50,7 +46,7 @@ async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
     # so we just allow it to fail within response handling some times, and
     # try to increase the chance of that by running this test a few times.
     for _ in range(10):
-        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+        with pytest.raises(TimeoutError):
             if isinstance(client, SyncClient):
 
                 def run():
@@ -63,23 +59,19 @@ async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
                 await asyncio.to_thread(run)
             else:
                 queue = asyncio.Queue()
-                async with asyncio.timeout(0):
-                    async with client.stream(
-                        method, url, content=request_body(queue)
-                    ) as resp:
-                        await anext(resp.content)
+                async with client.stream(
+                    method, url, content=request_body(queue), timeout=0
+                ) as resp:
+                    await anext(resp.content)
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    sys.version_info < (3, 11), reason="asyncio.timeout requires Python 3.11+"
-)
 async def test_response_content_timeout(client: Client | SyncClient, url: str) -> None:
     method = "POST"
     url = f"{url}/echo"
     # Anecdotally, the above test will have one of its runs timeout on the response body
     # in many cases, but check explicitly for good measure.
-    with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+    with pytest.raises(TimeoutError):
         if isinstance(client, SyncClient):
 
             def run():
@@ -93,12 +85,11 @@ async def test_response_content_timeout(client: Client | SyncClient, url: str) -
             await asyncio.to_thread(run)
         else:
             queue = asyncio.Queue()
-            async with asyncio.timeout(0.03):
-                async with client.stream(
-                    method, url, content=request_body(queue)
-                ) as resp:
-                    assert resp.status == 200
-                    await anext(resp.content)
+            async with client.stream(
+                method, url, content=request_body(queue), timeout=0.03
+            ) as resp:
+                assert resp.status == 200
+                await anext(resp.content)
 
 
 @pytest.mark.asyncio

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -31,6 +31,23 @@ def test_sync_request_minimal():
 
 
 @pytest.mark.asyncio
+async def test_request_timeout():
+    request = Request(method="GET", url="https://example.com/")
+    assert request.timeout is None
+
+    request = Request(method="GET", url="https://example.com/", timeout=5.0)
+    timeout = request.timeout
+    assert timeout is not None
+    assert 4.0 < timeout <= 5.0
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_invalid():
+    with pytest.raises(ValueError, match="Timeout must be non-negative"):
+        Request(method="GET", url="https://example.com/", timeout=-1.0)
+
+
+@pytest.mark.asyncio
 async def test_request_content_bytes():
     request = Request(
         method="DELETE",


### PR DESCRIPTION
## Summary

Adds an httpx-style keyword-only `timeout=` parameter to all async `Client` methods (`get`/`post`/`put`/`patch`/`delete`/`head`/`options`/`execute`/`stream`), matching the API `SyncClient` already has.

```python
response = await client.get("https://pyqwest.dev", timeout=2.0)
```

This also makes the async per-call example in `docs/usage.md` accurate again — it currently documents `await client.get(..., timeout=2.0)`, which stopped existing after #83.

## Design

I know #83 deliberately removed this in favor of `asyncio.wait_for`, so here's the case for bringing it back with different mechanics:

- The timeout is converted to a **deadline** when the call is made (same semantics as the sync contextvar deadline from #83), and the remaining time is applied as reqwest's total request timeout when the wire request is built.
- The deadline is carried **on the `Request`** (also exposed as `timeout=` on the `Request` constructor and a `timeout` property returning remaining seconds), which is how httpx carries per-request timeouts in `request.extensions`. That means it survives custom transports, time spent in middleware counts against the deadline, and retries share one deadline instead of each getting a fresh timeout — the retry middleware now forwards it when reconstructing requests.
- Unlike `asyncio.wait_for` around `stream()`, the reqwest total timeout also covers streaming response body reads, matching the sync client's behavior.
- Per-request granularity stays a single total timeout: reqwest only supports `Request::timeout` per call — `connect_timeout`/`read_timeout` are `ClientBuilder`-level — so the transport remains the place for those, as `convert_timeout` in the httpx adapter already documents.

Additional changes:

- The ASGI test transport now honors `request.timeout` (header wait and body reads), for parity with the WSGI transport honoring the sync contextvar timeout.
- Fixed a potential panic in `get_sync_timeout` when the deadline has already passed (`Instant` subtraction overflow) by saturating to zero, which reqwest treats as an immediate timeout.

## Testing

- `test_request_timeout` / `test_response_content_timeout` now exercise the native `timeout=` on the async branches (previously `asyncio.timeout`), across real HTTP and mock transports; the 3.11 skip is no longer needed.
- New validation tests for the async client (negative/inf/NaN) and `Request.timeout` property tests.
- Full suite passes (1119 passed, 147 skipped, 802 subtests); clippy pedantic and ruff clean.
- Manually verified against a slow local server: a 0.3s per-request timeout raises `TimeoutError` at 0.30s, both directly and through the retry middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)