### PR TITLE
Add macOS Intel (x86_64) wheels to release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         os:
           - macos-15
-          - macos-15-intel
           - ubuntu-24.04
           - windows-2025
         python:
@@ -97,3 +96,21 @@ jobs:
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ matrix.coverage == 'cov' }}
+
+  # pyvoy, which serves the test suite, has no macOS Intel wheels (Envoy dropped
+  # x86_64 macOS support), so we can't run tests on Intel runners. Just verify
+  # the wheel builds like in the release workflow.
+  build-macos-intel:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          args: --release --out dist -i 3.14
+          sccache: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,21 +96,3 @@ jobs:
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ matrix.coverage == 'cov' }}
-
-  # pyvoy, which serves the test suite, has no macOS Intel wheels (Envoy dropped
-  # x86_64 macOS support), so we can't run tests on Intel runners. Just verify
-  # the wheel builds like in the release workflow.
-  build-macos-intel:
-    runs-on: macos-15-intel
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.14"
-
-      - name: Build wheel
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          args: --release --out dist -i 3.14
-          sccache: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         os:
           - macos-15
+          - macos-15-intel
           - ubuntu-24.04
           - windows-2025
         python:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,6 +151,8 @@ jobs:
         platform:
           - runner: macos-15
             target: aarch64
+          - runner: macos-15-intel
+            target: x86_64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
Adds a `macos-15-intel` / `x86_64` entry to the macOS matrix in the release workflow so Intel Mac wheels are published alongside the existing arm64 ones. All release build steps were already parameterized on `matrix.platform.target`, so no other changes were needed. Using the native Intel runner (rather than cross-compiling from arm64) means setup-python provides real x86_64 interpreters, including PyPy.

Note the CI test suite can't cover Intel macOS because `pyvoy` (which serves the tests) has no macOS x86_64 wheels — Envoy dropped Intel macOS support. The wheel build itself was verified to compile on `macos-15-intel` in an earlier revision of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)