### PR TITLE
Add logging middleware

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,6 +175,42 @@ or `should_retry_response` to fit your needs, for example matching against `requ
         client.get("http://localhost/unsafe-method")  # will not retry
     ```
 
+#### Logging
+
+Logging middleware logs requests and responses to a standard library logger, by default
+the logger named `pyqwest`. Requests log at `INFO`, responses at `INFO` for statuses
+below 400 and `ERROR` otherwise, request failures at `ERROR`, and each received content
+chunk at `DEBUG`. The messages and levels can be customized by subclassing the middleware
+class and overriding `log_request`, `log_response`, `log_chunk`, or `log_error`.
+
+=== "async"
+
+    ```python
+    import logging
+
+    from pyqwest import Client, HTTPTransport
+    from pyqwest.middleware.logging import LoggingTransport
+
+
+    logger = logging.getLogger("myapp.http")
+    client = Client(transport=LoggingTransport(HTTPTransport(), logger))
+    await client.get("http://localhost/hello")  # logs the request and response
+    ```
+
+=== "sync"
+
+    ```python
+    import logging
+
+    from pyqwest import SyncClient, SyncHTTPTransport
+    from pyqwest.middleware.logging import SyncLoggingTransport
+
+
+    logger = logging.getLogger("myapp.http")
+    client = SyncClient(transport=SyncLoggingTransport(SyncHTTPTransport(), logger))
+    client.get("http://localhost/hello")  # logs the request and response
+    ```
+
 ### Proxies
 
 The transport can be configured to send all requests through a proxy by passing its URL.

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -671,6 +671,9 @@ class Response:
         it is not necessary to explicitly close the response.
         """
 
+    @property
+    def _read_pending(self) -> bool: ...
+
 class SyncClient:
     """A synchronous HTTP client.
 
@@ -1145,6 +1148,9 @@ class SyncResponse:
         Note that if your code is guaranteed to fully consume the response content,
         it is not necessary to explicitly close the response.
         """
+
+    @property
+    def _read_pending(self) -> bool: ...
 
 class FullResponse:
     """A fully buffered HTTP response."""

--- a/pyqwest/middleware/logging/__init__.py
+++ b/pyqwest/middleware/logging/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+__all__ = ["LoggingTransport", "SyncLoggingTransport"]
+
+from ._async import LoggingTransport
+from ._sync import SyncLoggingTransport

--- a/pyqwest/middleware/logging/_async.py
+++ b/pyqwest/middleware/logging/_async.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, final
+
+from pyqwest import Transport
+from pyqwest._pyqwest import Request, Response
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class LoggingTransport(Transport):
+    """Logging middleware for async clients.
+
+    Wrap a Transport with this class to log requests and responses to a standard
+    library logger. Requests log at INFO, responses at INFO for statuses below 400 and
+    ERROR otherwise, request failures at ERROR, and each received content chunk at DEBUG.
+
+    The messages and levels can be customized by subclassing this class and overriding
+    the `log_request`, `log_response`, `log_chunk`, and `log_error` methods.
+
+    Examples:
+        ```python
+        import logging
+
+        from pyqwest import Client, HTTPTransport
+        from pyqwest.middleware.logging import LoggingTransport
+
+        logger = logging.getLogger("myapp.http")
+        client = Client(transport=LoggingTransport(HTTPTransport(), logger))
+        await client.get("http://localhost/hello")  # logs the request and response
+        ```
+    """
+
+    _transport: Transport
+    _logger: logging.Logger
+
+    def __init__(
+        self, transport: Transport, logger: logging.Logger | None = None
+    ) -> None:
+        self._transport = transport
+        self._logger = logger if logger is not None else logging.getLogger("pyqwest")
+
+    @final
+    async def execute(self, request: Request) -> Response:
+        self.log_request(request)
+        try:
+            response = await self._transport.execute(request)
+        except Exception as e:
+            self.log_error(request, e)
+            raise
+        self.log_response(request, response)
+        return Response(
+            status=response.status,
+            http_version=response.http_version,
+            headers=response.headers,
+            content=_LoggingContent(self, request, response),
+            trailers=response.trailers,
+        )
+
+    def log_request(self, request: Request) -> None:
+        self._logger.info("Request: %s %s", request.method, request.url)
+
+    def log_response(self, request: Request, response: Response) -> None:
+        level = logging.ERROR if response.status >= 400 else logging.INFO
+        self._logger.log(
+            level, "Response: %d %s %s", response.status, request.method, request.url
+        )
+
+    def log_chunk(
+        self, request: Request, chunk: bytes | memoryview | bytearray
+    ) -> None:
+        self._logger.debug(
+            "Response chunk: %d bytes %s %s", len(chunk), request.method, request.url
+        )
+
+    def log_error(self, request: Request, error: Exception) -> None:
+        self._logger.error("Error: %r %s %s", error, request.method, request.url)
+
+
+class _LoggingContent:
+    def __init__(
+        self, transport: LoggingTransport, request: Request, response: Response
+    ) -> None:
+        self._transport = transport
+        self._request = request
+        self._response = response
+        self._iter = aiter(response.content)
+
+    def __aiter__(self) -> AsyncIterator[bytes | memoryview | bytearray]:
+        return self
+
+    async def __anext__(self) -> bytes | memoryview | bytearray:
+        try:
+            chunk = await anext(self._iter)
+        except StopAsyncIteration:
+            raise
+        except Exception as e:
+            self._transport.log_error(self._request, e)
+            raise
+        self._transport.log_chunk(self._request, chunk)
+        return chunk
+
+    async def aclose(self) -> None:
+        # Closing the wrapped response, not just its content iterator, releases the
+        # underlying stream even when nothing was read yet.
+        await self._response.aclose()
+
+    @property
+    def _read_pending(self) -> bool:
+        return self._response._read_pending  # noqa: SLF001

--- a/pyqwest/middleware/logging/_sync.py
+++ b/pyqwest/middleware/logging/_sync.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, final
+
+from pyqwest import SyncTransport
+from pyqwest._pyqwest import SyncRequest, SyncResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class SyncLoggingTransport(SyncTransport):
+    """Logging middleware for sync clients.
+
+    Wrap a SyncTransport with this class to log requests and responses to a standard
+    library logger. Requests log at INFO, responses at INFO for statuses below 400 and
+    ERROR otherwise, request failures at ERROR, and each received content chunk at DEBUG.
+
+    The messages and levels can be customized by subclassing this class and overriding
+    the `log_request`, `log_response`, `log_chunk`, and `log_error` methods.
+
+    Examples:
+        ```python
+        import logging
+
+        from pyqwest import SyncClient, SyncHTTPTransport
+        from pyqwest.middleware.logging import SyncLoggingTransport
+
+        logger = logging.getLogger("myapp.http")
+        client = SyncClient(transport=SyncLoggingTransport(SyncHTTPTransport(), logger))
+        client.get("http://localhost/hello")  # logs the request and response
+        ```
+    """
+
+    _transport: SyncTransport
+    _logger: logging.Logger
+
+    def __init__(
+        self, transport: SyncTransport, logger: logging.Logger | None = None
+    ) -> None:
+        self._transport = transport
+        self._logger = logger if logger is not None else logging.getLogger("pyqwest")
+
+    @final
+    def execute_sync(self, request: SyncRequest) -> SyncResponse:
+        self.log_request(request)
+        try:
+            response = self._transport.execute_sync(request)
+        except Exception as e:
+            self.log_error(request, e)
+            raise
+        self.log_response(request, response)
+        return SyncResponse(
+            status=response.status,
+            http_version=response.http_version,
+            headers=response.headers,
+            content=_LoggingContent(self, request, response),
+            trailers=response.trailers,
+        )
+
+    def log_request(self, request: SyncRequest) -> None:
+        self._logger.info("Request: %s %s", request.method, request.url)
+
+    def log_response(self, request: SyncRequest, response: SyncResponse) -> None:
+        level = logging.ERROR if response.status >= 400 else logging.INFO
+        self._logger.log(
+            level, "Response: %d %s %s", response.status, request.method, request.url
+        )
+
+    def log_chunk(
+        self, request: SyncRequest, chunk: bytes | memoryview | bytearray
+    ) -> None:
+        self._logger.debug(
+            "Response chunk: %d bytes %s %s", len(chunk), request.method, request.url
+        )
+
+    def log_error(self, request: SyncRequest, error: Exception) -> None:
+        self._logger.error("Error: %r %s %s", error, request.method, request.url)
+
+
+class _LoggingContent:
+    def __init__(
+        self,
+        transport: SyncLoggingTransport,
+        request: SyncRequest,
+        response: SyncResponse,
+    ) -> None:
+        self._transport = transport
+        self._request = request
+        self._response = response
+        self._iter = iter(response.content)
+
+    def __iter__(self) -> Iterator[bytes | memoryview | bytearray]:
+        return self
+
+    def __next__(self) -> bytes | memoryview | bytearray:
+        try:
+            chunk = next(self._iter)
+        except StopIteration:
+            raise
+        except Exception as e:
+            self._transport.log_error(self._request, e)
+            raise
+        self._transport.log_chunk(self._request, chunk)
+        return chunk
+
+    def close(self) -> None:
+        # Closing the wrapped response, not just its content iterator, releases the
+        # underlying stream even when nothing was read yet.
+        self._response.close()
+
+    @property
+    def _read_pending(self) -> bool:
+        return self._response._read_pending  # noqa: SLF001

--- a/tests/middleware/logging/test_async.py
+++ b/tests/middleware/logging/test_async.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyqwest import Client
+from pyqwest.middleware.logging import LoggingTransport
+from pyqwest.testing import ASGITransport
+
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
+
+
+class App:
+    def __init__(self):
+        self.status = 200
+        self.connection_error = False
+        self.chunks = [b"hello", b"world"]
+
+    async def __call__(
+        self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:
+        if scope["type"] != "http":
+            return
+        if self.connection_error:
+            raise ConnectionError
+        while True:
+            message = await receive()
+            if message["type"] == "http.request" and not message.get(
+                "more_body", False
+            ):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status,
+                "headers": [],
+                "trailers": False,
+            }
+        )
+        for i, chunk in enumerate(self.chunks):
+            more_body = i < len(self.chunks) - 1
+            await send(
+                {"type": "http.response.body", "body": chunk, "more_body": more_body}
+            )
+
+
+@pytest.fixture
+def app():
+    return App()
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test-pyqwest-logging-async")
+
+
+@pytest.fixture
+def client(app: App, logger: logging.Logger):
+    return Client(LoggingTransport(ASGITransport(app), logger))
+
+
+def messages(
+    caplog: pytest.LogCaptureFixture, logger: logging.Logger
+) -> list[tuple[int, str]]:
+    return [
+        (record.levelno, record.getMessage())
+        for record in caplog.records
+        if record.name == logger.name
+    ]
+
+
+@pytest.mark.asyncio
+async def test_success(
+    client: Client, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    res = await client.get("http://localhost/path")
+    assert res.status == 200
+    assert res.content == b"helloworld"
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/path"),
+        (logging.INFO, "Response: 200 GET http://localhost/path"),
+        (logging.DEBUG, "Response chunk: 5 bytes GET http://localhost/path"),
+        (logging.DEBUG, "Response chunk: 5 bytes GET http://localhost/path"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_error_status(
+    app: App, client: Client, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    app.status = 500
+    res = await client.get("http://localhost")
+    assert res.status == 500
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.ERROR, "Response: 500 GET http://localhost/"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_connection_error(
+    app: App, client: Client, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    app.connection_error = True
+    with pytest.raises(ConnectionError):
+        await client.get("http://localhost")
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.ERROR, "Error: ConnectionError() GET http://localhost/"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_chunks_without_debug(
+    client: Client, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    res = await client.get("http://localhost")
+    assert res.status == 200
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.INFO, "Response: 200 GET http://localhost/"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_close_before_read(
+    client: Client, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    async with client.stream("GET", "http://localhost"):
+        pass
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.INFO, "Response: 200 GET http://localhost/"),
+    ]

--- a/tests/middleware/logging/test_sync.py
+++ b/tests/middleware/logging/test_sync.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyqwest import SyncClient, SyncRequest
+from pyqwest.middleware.logging import SyncLoggingTransport
+from pyqwest.testing import WSGITransport
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    if sys.version_info >= (3, 11):
+        from wsgiref.types import StartResponse, WSGIEnvironment
+    else:
+        from _typeshed.wsgi import StartResponse, WSGIEnvironment
+
+
+class App:
+    def __init__(self):
+        self.status = 200
+        self.connection_error = False
+        self.chunks = [b"hello", b"world"]
+
+    def __call__(
+        self, environ: WSGIEnvironment, start_response: StartResponse
+    ) -> Iterable[bytes]:
+        if self.connection_error:
+            try:
+                raise ConnectionError  # noqa: TRY301
+            except ConnectionError:
+                start_response("500 Internal Server Error", [], sys.exc_info())
+            return []
+        start_response(f"{self.status} {self.status}", [])
+        return self.chunks
+
+
+@pytest.fixture
+def app():
+    return App()
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test-pyqwest-logging")
+
+
+@pytest.fixture
+def client(app: App, logger: logging.Logger):
+    return SyncClient(SyncLoggingTransport(WSGITransport(app), logger))
+
+
+def messages(
+    caplog: pytest.LogCaptureFixture, logger: logging.Logger
+) -> list[tuple[int, str]]:
+    return [
+        (record.levelno, record.getMessage())
+        for record in caplog.records
+        if record.name == logger.name
+    ]
+
+
+def test_success(
+    client: SyncClient, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    res = client.get("http://localhost/path")
+    assert res.status == 200
+    assert res.content == b"helloworld"
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/path"),
+        (logging.INFO, "Response: 200 GET http://localhost/path"),
+        (logging.DEBUG, "Response chunk: 5 bytes GET http://localhost/path"),
+        (logging.DEBUG, "Response chunk: 5 bytes GET http://localhost/path"),
+    ]
+
+
+def test_error_status(
+    app: App,
+    client: SyncClient,
+    logger: logging.Logger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    app.status = 500
+    res = client.get("http://localhost")
+    assert res.status == 500
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.ERROR, "Response: 500 GET http://localhost/"),
+    ]
+
+
+def test_connection_error(
+    app: App,
+    client: SyncClient,
+    logger: logging.Logger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    app.connection_error = True
+    with pytest.raises(ConnectionError):
+        client.get("http://localhost")
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.ERROR, "Error: WSGIConnectionError('') GET http://localhost/"),
+    ]
+
+
+def test_no_chunks_without_debug(
+    client: SyncClient, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger=logger.name)
+    res = client.get("http://localhost")
+    assert res.status == 200
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.INFO, "Response: 200 GET http://localhost/"),
+    ]
+
+
+def test_default_logger(app: App, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="pyqwest")
+    client = SyncClient(SyncLoggingTransport(WSGITransport(app)))
+    res = client.get("http://localhost")
+    assert res.status == 200
+    assert [r.name for r in caplog.records if r.name == "pyqwest"] == [
+        "pyqwest",
+        "pyqwest",
+    ]
+
+
+def test_stream_close_before_read(
+    client: SyncClient, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    with client.stream("GET", "http://localhost"):
+        pass
+    assert messages(caplog, logger) == [
+        (logging.INFO, "Request: GET http://localhost/"),
+        (logging.INFO, "Response: 200 GET http://localhost/"),
+    ]
+
+
+def test_custom_messages(
+    app: App, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    class MyLoggingTransport(SyncLoggingTransport):
+        def log_request(self, request: SyncRequest) -> None:
+            self._logger.warning("Calling %s", request.url)
+
+    caplog.set_level(logging.INFO, logger=logger.name)
+    client = SyncClient(MyLoggingTransport(WSGITransport(app), logger))
+    res = client.get("http://localhost")
+    assert res.status == 200
+    assert messages(caplog, logger) == [
+        (logging.WARNING, "Calling http://localhost/"),
+        (logging.INFO, "Response: 200 GET http://localhost/"),
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -636,12 +636,12 @@ async def test_close_pending_read(async_client: Client, url: str) -> None:
 
         read_task = asyncio.create_task(read_content())
 
-        while not resp._read_pending:  # ty: ignore[unresolved-attribute]  # noqa: ASYNC110
+        while not resp._read_pending:  # noqa: ASYNC110
             await asyncio.sleep(0.001)
 
     with pytest.raises(ReadError):
         await read_task
-    assert not resp._read_pending  # ty: ignore[unresolved-attribute]
+    assert not resp._read_pending
 
 
 @pytest.mark.asyncio
@@ -673,7 +673,7 @@ async def test_close_pending_read_sync(sync_client: SyncClient, url: str) -> Non
             read_thread = threading.Thread(target=read_content)
             read_thread.start()
 
-            while not resp._read_pending:  # ty: ignore[unresolved-attribute]
+            while not resp._read_pending:
                 time.sleep(0.001)
 
         read_thread.join()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -18,7 +18,7 @@ async def test_response_minimal():
     assert response.headers == Headers()
     assert await anext(response.content, None) is None
     assert response.trailers == Headers()
-    assert not response._read_pending  # ty: ignore[unresolved-attribute]
+    assert not response._read_pending
 
 
 @pytest.mark.asyncio
@@ -63,7 +63,7 @@ def test_sync_response_minimal():
     assert response.headers == Headers()
     assert next(response.content, None) is None
     assert response.trailers == Headers()
-    assert not response._read_pending  # ty: ignore[unresolved-attribute]
+    assert not response._read_pending
 
 
 def test_sync_response_content_bytes():


### PR DESCRIPTION
Adds `pyqwest.middleware.logging` with `LoggingTransport` and `SyncLoggingTransport`, middleware that logs requests and responses to a standard library logger (default: the `pyqwest` logger), following the same pattern as the retry middleware. Requests log at INFO, responses at INFO for statuses below 400 and ERROR otherwise, request failures at ERROR, and each received content chunk at DEBUG; messages and levels can be customized by subclassing and overriding `log_request`, `log_response`, `log_chunk`, or `log_error`. To log chunks, the middleware wraps the response with a content object whose `close()`/`aclose()` closes the inner response, so closing the wrapper before reading still releases the underlying stream, and trailers stay live since the `Response` constructor keeps the passed `Headers` object. Also adds the `_read_pending` property to the `Response`/`SyncResponse` type stubs (it exists on the native classes), removing previously needed `ty: ignore` comments in tests. Includes sync and async tests plus a usage docs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)