### PR TITLE
Refactor headers coercion into shared Headers helpers

### DIFF
--- a/src/asyncio/client.rs
+++ b/src/asyncio/client.rs
@@ -128,15 +128,9 @@ impl Client {
         content: Option<Bound<'py, PyAny>>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let headers = if let Some(headers) = headers {
-            if let Ok(headers) = headers.cast::<Headers>() {
-                Some(headers.clone())
-            } else {
-                Some(Bound::new(py, Headers::py_new(Some(headers))?)?)
-            }
-        } else {
-            None
-        };
+        let headers = headers
+            .map(|headers| Headers::coerce(py, &headers))
+            .transpose()?;
         let request = Request::new(
             py,
             method,
@@ -166,15 +160,9 @@ impl Client {
         content: Option<Bound<'py, PyAny>>,
         params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let headers = if let Some(headers) = headers {
-            if let Ok(headers) = headers.cast::<Headers>() {
-                Some(headers.clone())
-            } else {
-                Some(Bound::new(py, Headers::py_new(Some(headers))?)?)
-            }
-        } else {
-            None
-        };
+        let headers = headers
+            .map(|headers| Headers::coerce(py, &headers))
+            .transpose()?;
         let request = Request::py_new(py, method, url, headers, content, params)?;
         match &self.transport {
             Transport::Http(transport) => transport.do_stream(py, &request),

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -38,6 +38,27 @@ impl Headers {
         }
     }
 
+    /// Returns the object itself if it is already a `Headers`, otherwise
+    /// constructs a `Headers` from it as `Headers(obj)` would.
+    pub(crate) fn coerce<'py>(
+        py: Python<'py>,
+        obj: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, Headers>> {
+        if let Ok(headers) = obj.cast::<Headers>() {
+            Ok(headers.clone())
+        } else {
+            Bound::new(py, Headers::py_new(Some(obj.clone()))?)
+        }
+    }
+
+    /// Appends all entries, converted to HTTP values, to `headers`.
+    pub(crate) fn append_to(&self, py: Python<'_>, headers: &mut HeaderMap) -> PyResult<()> {
+        for (name, value) in self.store.lock_py_attached(py).unwrap().iter() {
+            headers.append(name, value.as_http(py)?);
+        }
+        Ok(())
+    }
+
     pub(crate) fn fill(&self, headers: HeaderMap) {
         let mut store = self.store.lock().unwrap();
         store.reserve(headers.len());

--- a/src/shared/request.rs
+++ b/src/shared/request.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use http::HeaderValue;
-use pyo3::sync::MutexExt as _;
 use pyo3::types::{PyAnyMethods as _, PyDict, PyDictMethods as _, PyString, PyStringMethods as _};
 use pyo3::{exceptions::PyValueError, Py, PyResult, Python};
 use pyo3::{Bound, PyAny};
@@ -62,10 +61,7 @@ impl RequestHead {
         if http3 {
             *req.version_mut() = http::Version::HTTP_3;
         }
-        let hdrs = self.headers.bind(py).borrow();
-        for (name, value) in hdrs.store.lock_py_attached(py).unwrap().iter() {
-            req.headers_mut().append(name, value.as_http(py)?);
-        }
+        self.headers.get().append_to(py, req.headers_mut())?;
         if self.json && !req.headers().contains_key(http::header::CONTENT_TYPE) {
             req.headers_mut()
                 .insert(http::header::CONTENT_TYPE, CONTENT_TYPE_JSON);

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -145,15 +145,9 @@ impl SyncClient {
         } else {
             None
         };
-        let headers = if let Some(headers) = headers {
-            if let Ok(headers) = headers.cast::<Headers>() {
-                Some(headers.clone())
-            } else {
-                Some(Bound::new(py, Headers::py_new(Some(headers))?)?)
-            }
-        } else {
-            None
-        };
+        let headers = headers
+            .map(|headers| Headers::coerce(py, &headers))
+            .transpose()?;
         let request = SyncRequest::new(py, method, url, headers, content, params, &self.constants)?;
         match &self.transport {
             Transport::Http(transport) => transport.do_execute(py, &request),
@@ -183,15 +177,9 @@ impl SyncClient {
         } else {
             None
         };
-        let headers = if let Some(headers) = headers {
-            if let Ok(headers) = headers.cast::<Headers>() {
-                Some(headers.clone())
-            } else {
-                Some(Bound::new(py, Headers::py_new(Some(headers))?)?)
-            }
-        } else {
-            None
-        };
+        let headers = headers
+            .map(|headers| Headers::coerce(py, &headers))
+            .transpose()?;
         let request = SyncRequest::new(py, method, url, headers, content, params, &self.constants)?;
         let response = match &self.transport {
             Transport::Http(transport) => transport.do_stream(py, &request)?.into_pyobject(py),


### PR DESCRIPTION
Deduplicates two repeated patterns around `Headers` into helpers on the type itself:

- `Headers::coerce(py, obj)` — returns the object as-is if it is already a `Headers`, otherwise constructs one from it as `Headers(obj)` would. Replaces the four identical cast-or-construct blocks in `asyncio/client.rs` (`execute`, `stream`) and `sync/client.rs` (`execute`, `stream`).
- `Headers::append_to(py, &mut HeaderMap)` — appends all entries converted to HTTP values. Replaces the store-to-HeaderMap loop in `RequestHead::new_reqwest`.

No behavior change. #194 has the same two patterns in its new `Proxy` class and can switch to these helpers once either lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)