### PR TITLE
Add httpx-style logging inlined in the HTTP transports

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -233,3 +233,45 @@ setting by passing `timeout` for sync clients or using `asyncio.wait_for` or
     ```python
     response = client.get("https://pyqwest.dev", timeout=2.0)
     ```
+
+## Logging
+
+pyqwest integrates with Python's standard [`logging`](https://docs.python.org/3/library/logging.html)
+module using two loggers, both emitting at `DEBUG` level:
+
+- `pyqwest.access` — one summary line per HTTP request, in the same format as httpx,
+  emitted once response headers are received.
+- `pyqwest` — granular request lifecycle records, e.g. when a request is sent or
+  fails without a response.
+
+Unlike httpx, no records are emitted at `INFO` level, so enabling `INFO` for your whole
+application will not also log every HTTP request. Opt in explicitly instead:
+
+```python
+import logging
+
+logging.basicConfig(
+    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logging.getLogger("pyqwest.access").setLevel(logging.DEBUG)
+
+response = client.get("https://pyqwest.dev")
+```
+
+Will send log output such as:
+
+```
+DEBUG [2026-07-24 12:34:56] pyqwest.access - HTTP Request: GET https://pyqwest.dev "HTTP/2 200 OK"
+```
+
+Setting the `pyqwest` logger to `DEBUG` instead enables the full request lifecycle,
+including the access records through standard logger inheritance. The two never
+duplicate each other, and an explicit level on `pyqwest.access` always takes
+precedence, so the access log can be enabled on its own or silenced while keeping
+the granular records.
+
+The log records are emitted directly from the Rust HTTP transports with no overhead
+when neither logger is enabled for `DEBUG`. Requests that fail without a response,
+such as connection errors, appear only on the `pyqwest` logger, keeping the access
+log to requests with responses like httpx.

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -136,6 +136,32 @@ pub(crate) struct ConstantsInner {
     /// The string "url.full".
     pub url_full: Py<PyString>,
 
+    // Logging.
+    /// The bound method `isEnabledFor` of the "pyqwest" logger.
+    pub(super) logger_is_enabled_for: Py<PyAny>,
+    /// The bound method `debug` of the "pyqwest" logger.
+    pub(super) logger_debug: Py<PyAny>,
+    /// The bound method `isEnabledFor` of the "pyqwest.access" logger.
+    pub(super) access_logger_is_enabled_for: Py<PyAny>,
+    /// The bound method `debug` of the "pyqwest.access" logger.
+    pub(super) access_logger_debug: Py<PyAny>,
+    /// The level `logging.DEBUG`.
+    pub(super) logging_debug_level: Py<PyAny>,
+    /// The format string for access log records.
+    pub(super) http_request_log: Py<PyString>,
+    /// The format string for request started log records.
+    pub(super) log_request_started: Py<PyString>,
+    /// The format string for request failed log records.
+    pub(super) log_request_failed: Py<PyString>,
+    /// The string "HTTP/1.0".
+    pub(super) log_http_1_0: Py<PyString>,
+    /// The string "HTTP/1.1".
+    pub(super) log_http_1_1: Py<PyString>,
+    /// The string "HTTP/2".
+    pub(super) log_http_2: Py<PyString>,
+    /// The string "HTTP/3".
+    pub(super) log_http_3: Py<PyString>,
+
     /// The string `add`.
     pub(super) add: Py<PyString>,
     /// The string `create_histogram`.
@@ -473,6 +499,10 @@ impl Constants {
             .getattr("ContextVar")?
             .call1(("pyqwest_timeout",))?;
 
+        let logging = py.import("logging")?;
+        let logger = logging.call_method1("getLogger", ("pyqwest",))?;
+        let access_logger = logging.call_method1("getLogger", ("pyqwest.access",))?;
+
         let otel_metrics = py.import("opentelemetry.metrics")?;
         let otel_propagate = py.import("opentelemetry.propagate")?;
         let otel_trace = py.import("opentelemetry.trace")?;
@@ -543,6 +573,19 @@ impl Constants {
                 server_address: PyString::new(py, "server.address").unbind(),
                 server_port: PyString::new(py, "server.port").unbind(),
                 url_full: PyString::new(py, "url.full").unbind(),
+
+                logger_is_enabled_for: logger.getattr("isEnabledFor")?.unbind(),
+                logger_debug: logger.getattr("debug")?.unbind(),
+                access_logger_is_enabled_for: access_logger.getattr("isEnabledFor")?.unbind(),
+                access_logger_debug: access_logger.getattr("debug")?.unbind(),
+                logging_debug_level: logging.getattr("DEBUG")?.unbind(),
+                http_request_log: PyString::new(py, "HTTP Request: %s %s \"%s %d %s\"").unbind(),
+                log_request_started: PyString::new(py, "Sending HTTP request: %s %s").unbind(),
+                log_request_failed: PyString::new(py, "HTTP request failed: %s %s (%r)").unbind(),
+                log_http_1_0: PyString::new(py, "HTTP/1.0").unbind(),
+                log_http_1_1: PyString::new(py, "HTTP/1.1").unbind(),
+                log_http_2: PyString::new(py, "HTTP/2").unbind(),
+                log_http_3: PyString::new(py, "HTTP/3").unbind(),
 
                 add: PyString::new(py, "add").unbind(),
                 create_histogram: PyString::new(py, "create_histogram").unbind(),

--- a/src/shared/otel.rs
+++ b/src/shared/otel.rs
@@ -31,6 +31,7 @@ struct InstrumentationInner {
 #[derive(Clone)]
 pub(crate) struct Instrumentation {
     inner: Option<Arc<InstrumentationInner>>,
+    constants: Constants,
 }
 
 impl Instrumentation {
@@ -42,7 +43,10 @@ impl Instrumentation {
         constants: &Constants,
     ) -> PyResult<Self> {
         if !enable_otel {
-            return Ok(Self { inner: None });
+            return Ok(Self {
+                inner: None,
+                constants: constants.clone(),
+            });
         }
         let meter_provider = match meter_provider {
             Some(mp) => mp,
@@ -88,12 +92,56 @@ impl Instrumentation {
                 metric_http_client_request_duration: metric_http_client_request_duration.unbind(),
                 constants: constants.clone(),
             })),
+            constants: constants.clone(),
         })
     }
 
+    /// Prepares log records for this request if the "pyqwest" logger (granular
+    /// lifecycle records) or the "pyqwest.access" logger (one httpx-style summary
+    /// line per request) has DEBUG enabled. The level checks happen per request so
+    /// runtime logging configuration changes are respected like in pure Python.
+    fn start_log(
+        &self,
+        py: Python<'_>,
+        request: &RequestHead,
+    ) -> PyResult<Option<Arc<LogOperation>>> {
+        let constants = &self.constants;
+        let debug = constants
+            .logger_is_enabled_for
+            .bind(py)
+            .call1((&constants.logging_debug_level,))?
+            .is_truthy()?;
+        let access = constants
+            .access_logger_is_enabled_for
+            .bind(py)
+            .call1((&constants.logging_debug_level,))?
+            .is_truthy()?;
+        if !debug && !access {
+            return Ok(None);
+        }
+        let method = request.method(py)?;
+        let url = PyString::new(py, request.url()).unbind();
+        if debug {
+            constants.logger_debug.bind(py).call1((
+                &constants.log_request_started,
+                &method,
+                &url,
+            ))?;
+        }
+        Ok(Some(Arc::new(LogOperation {
+            method,
+            url,
+            debug,
+            access,
+            response_info: Mutex::new(None),
+            constants: constants.clone(),
+        })))
+    }
+
     pub(crate) fn start(&self, py: Python<'_>, request: &RequestHead) -> PyResult<Operation> {
+        let log = self.start_log(py, request)?;
         let Some(inner) = self.inner.as_ref() else {
-            return Ok(Operation { inner: None });
+            return Ok(Operation { inner: None, log });
         };
         let http_method = request.method(py)?;
         let base_attrs = PyDict::new(py);
@@ -145,13 +193,66 @@ impl Instrumentation {
                 instrumentation: inner.clone(),
                 constants: inner.constants.clone(),
             })),
+            log,
         })
     }
 }
 
+#[derive(Clone, Copy)]
 struct ResponseInfo {
     status_code: http::StatusCode,
     http_version: http::Version,
+}
+
+struct LogOperation {
+    method: Py<PyString>,
+    url: Py<PyString>,
+    /// Whether the "pyqwest" logger has DEBUG enabled.
+    debug: bool,
+    /// Whether the "pyqwest.access" logger has DEBUG enabled.
+    access: bool,
+    response_info: Mutex<Option<ResponseInfo>>,
+    constants: Constants,
+}
+
+impl LogOperation {
+    fn emit(&self, py: Python<'_>, err: Option<&PyErr>) -> PyResult<()> {
+        let constants = &self.constants;
+        let Some(info) = self.response_info.lock_py_attached(py).unwrap().take() else {
+            // Requests that failed without a response, e.g. connection errors, only
+            // get a granular record, keeping the access log to responses like httpx.
+            if let (true, Some(err)) = (self.debug, err) {
+                constants.logger_debug.bind(py).call1((
+                    &constants.log_request_failed,
+                    &self.method,
+                    &self.url,
+                    err.value(py),
+                ))?;
+            }
+            return Ok(());
+        };
+        // The response summary is only recorded on the access logger. It is a child
+        // of the "pyqwest" logger so enabling that at DEBUG includes it by default,
+        // without duplicating a granular record for the same event.
+        if !self.access {
+            return Ok(());
+        }
+        let version = match info.http_version {
+            http::Version::HTTP_10 => &constants.log_http_1_0,
+            http::Version::HTTP_2 => &constants.log_http_2,
+            http::Version::HTTP_3 => &constants.log_http_3,
+            _ => &constants.log_http_1_1,
+        };
+        constants.access_logger_debug.bind(py).call1((
+            &constants.http_request_log,
+            &self.method,
+            &self.url,
+            version,
+            constants.status_code(py, info.status_code),
+            info.status_code.canonical_reason().unwrap_or_default(),
+        ))?;
+        Ok(())
+    }
 }
 
 struct OperationInner {
@@ -168,6 +269,7 @@ struct OperationInner {
 #[derive(Clone)]
 pub(crate) struct Operation {
     inner: Option<Arc<OperationInner>>,
+    log: Option<Arc<LogOperation>>,
 }
 
 impl Operation {
@@ -191,18 +293,22 @@ impl Operation {
     }
 
     pub(crate) fn fill_response(&self, response: &reqwest::Response) {
-        let Some(inner) = self.inner.as_ref() else {
-            return;
-        };
-        let mut response_info = inner.response_info.lock().unwrap();
-
-        *response_info = Some(ResponseInfo {
+        let info = ResponseInfo {
             status_code: response.status(),
             http_version: response.version(),
-        });
+        };
+        if let Some(inner) = self.inner.as_ref() {
+            *inner.response_info.lock().unwrap() = Some(info);
+        }
+        if let Some(log) = self.log.as_ref() {
+            *log.response_info.lock().unwrap() = Some(info);
+        }
     }
 
     pub(crate) fn end(&self, py: Python<'_>, err: Option<&PyErr>) -> PyResult<()> {
+        if let Some(log) = self.log.as_ref() {
+            log.emit(py, err)?;
+        }
         let Some(inner) = self.inner.as_ref() else {
             return Ok(());
         };

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
+from pyqwest import HTTPTransport, SyncHTTPTransport
 from pyqwest.httpx import AsyncPyqwestTransport, PyqwestTransport
 from pyqwest.testing import ASGITransport, WSGITransport
 
@@ -204,3 +206,42 @@ def test_sync_timeout() -> None:
             client.get("http://localhost/")
     finally:
         release.set()
+
+
+def access_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.name == "pyqwest.access"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_scheme", ["http"], indirect=True)
+@pytest.mark.parametrize("http_version", ["h1"], indirect=True)
+async def test_async_access_log(url: str, caplog: pytest.LogCaptureFixture) -> None:
+    async with HTTPTransport() as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with caplog.at_level(logging.DEBUG, logger="pyqwest.access"):
+                res = await client.get(f"{url}/echo")
+    assert res.status_code == 200
+
+    records = access_records(caplog)
+    assert len(records) == 1
+    assert records[0].getMessage() == f'HTTP Request: GET {url}/echo "HTTP/1.1 200 OK"'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_scheme", ["http"], indirect=True)
+@pytest.mark.parametrize("http_version", ["h1"], indirect=True)
+async def test_sync_access_log(url: str, caplog: pytest.LogCaptureFixture) -> None:
+    def run() -> httpx.Response:
+        with SyncHTTPTransport() as pyqwest_transport:
+            transport = PyqwestTransport(pyqwest_transport)
+            with httpx.Client(transport=transport) as client:
+                return client.get(f"{url}/echo")
+
+    with caplog.at_level(logging.DEBUG, logger="pyqwest.access"):
+        res = await asyncio.to_thread(run)
+    assert res.status_code == 200
+
+    records = access_records(caplog)
+    assert len(records) == 1
+    assert records[0].getMessage() == f'HTTP Request: GET {url}/echo "HTTP/1.1 200 OK"'

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -89,7 +89,7 @@ async def test_debug_log(
 
     records = records_for(caplog, DEBUG_LOGGER)
     assert [record.getMessage() for record in records] == [
-        f"Sending HTTP request: GET {url}",
+        f"Sending HTTP request: GET {url}"
     ]
     assert records[0].levelno == logging.DEBUG
     # The access logger inherits DEBUG from its "pyqwest" parent, completing the
@@ -120,7 +120,7 @@ async def test_debug_log_with_access_overridden(
     assert not records_for(caplog, ACCESS_LOGGER)
     records = records_for(caplog, DEBUG_LOGGER)
     assert [record.getMessage() for record in records] == [
-        f"Sending HTTP request: GET {url}",
+        f"Sending HTTP request: GET {url}"
     ]
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+
+import pytest
+
+from pyqwest import Client, HTTPVersion, SyncClient
+
+pytestmark = [
+    pytest.mark.parametrize("http_scheme", ["http"], indirect=True),
+    pytest.mark.parametrize("http_version", ["h1", "h2"], indirect=True),
+    pytest.mark.parametrize("client_type", ["async", "sync"]),
+]
+
+DEBUG_LOGGER = "pyqwest"
+ACCESS_LOGGER = "pyqwest.access"
+
+
+def version_display(http_version: HTTPVersion | None) -> str:
+    return "HTTP/2" if http_version == HTTPVersion.HTTP2 else "HTTP/1.1"
+
+
+def records_for(caplog: pytest.LogCaptureFixture, name: str) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.name == name]
+
+
+async def _get(client: Client | SyncClient, url: str):
+    if isinstance(client, SyncClient):
+        return await asyncio.to_thread(client.get, url)
+    return await client.get(url)
+
+
+@pytest.mark.asyncio
+async def test_access_log(
+    client: Client | SyncClient,
+    url: str,
+    http_version: HTTPVersion | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = f"{url}/echo"
+    with caplog.at_level(logging.DEBUG, logger=ACCESS_LOGGER):
+        resp = await _get(client, url)
+    assert resp.status == 200
+
+    records = records_for(caplog, ACCESS_LOGGER)
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.DEBUG
+    version = version_display(http_version)
+    assert record.getMessage() == f'HTTP Request: GET {url} "{version} 200 OK"'
+    assert record.args == ("GET", url, version, 200, "OK")
+    # Enabling the access child does not enable the parent "pyqwest" logger.
+    assert not records_for(caplog, DEBUG_LOGGER)
+
+
+@pytest.mark.asyncio
+async def test_access_log_error_status(
+    client: Client | SyncClient,
+    url: str,
+    http_version: HTTPVersion | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = f"{url}/not-found"
+    with caplog.at_level(logging.DEBUG, logger=ACCESS_LOGGER):
+        resp = await _get(client, url)
+    assert resp.status == 404
+
+    records = records_for(caplog, ACCESS_LOGGER)
+    assert len(records) == 1
+    version = version_display(http_version)
+    assert (
+        records[0].getMessage() == f'HTTP Request: GET {url} "{version} 404 Not Found"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_debug_log(
+    client: Client | SyncClient,
+    url: str,
+    http_version: HTTPVersion | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = f"{url}/echo"
+    with caplog.at_level(logging.DEBUG, logger=DEBUG_LOGGER):
+        resp = await _get(client, url)
+    assert resp.status == 200
+
+    records = records_for(caplog, DEBUG_LOGGER)
+    assert [record.getMessage() for record in records] == [
+        f"Sending HTTP request: GET {url}",
+    ]
+    assert records[0].levelno == logging.DEBUG
+    # The access logger inherits DEBUG from its "pyqwest" parent, completing the
+    # request lifecycle without duplicated records.
+    access_records = records_for(caplog, ACCESS_LOGGER)
+    assert len(access_records) == 1
+    version = version_display(http_version)
+    assert (
+        access_records[0].getMessage() == f'HTTP Request: GET {url} "{version} 200 OK"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_debug_log_with_access_overridden(
+    client: Client | SyncClient, url: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    url = f"{url}/echo"
+    access_logger = logging.getLogger(ACCESS_LOGGER)
+    with caplog.at_level(logging.DEBUG, logger=DEBUG_LOGGER):
+        access_logger.setLevel(logging.INFO)
+        try:
+            resp = await _get(client, url)
+        finally:
+            access_logger.setLevel(logging.NOTSET)
+    assert resp.status == 200
+
+    # An explicit level on the access child overrides the inherited DEBUG.
+    assert not records_for(caplog, ACCESS_LOGGER)
+    records = records_for(caplog, DEBUG_LOGGER)
+    assert [record.getMessage() for record in records] == [
+        f"Sending HTTP request: GET {url}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_logged(
+    client: Client | SyncClient,
+    url: str,
+    http_version: HTTPVersion | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = f"{url}/echo"
+    with caplog.at_level(logging.DEBUG, logger=ACCESS_LOGGER):
+        if isinstance(client, SyncClient):
+
+            def run() -> bytes:
+                with client.stream("POST", url, content=b"Hello, World!") as resp:
+                    return b"".join(resp.content)
+
+            content = await asyncio.to_thread(run)
+        else:
+            async with client.stream("POST", url, content=b"Hello, World!") as resp:
+                content = b""
+                async for chunk in resp.content:
+                    content += chunk
+    assert content == b"Hello, World!"
+
+    records = records_for(caplog, ACCESS_LOGGER)
+    assert len(records) == 1
+    version = version_display(http_version)
+    assert records[0].getMessage() == f'HTTP Request: POST {url} "{version} 200 OK"'
+
+
+@pytest.mark.asyncio
+async def test_not_logged_at_info(
+    client: Client | SyncClient, url: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    url = f"{url}/echo"
+    with (
+        caplog.at_level(logging.INFO, logger=DEBUG_LOGGER),
+        caplog.at_level(logging.INFO, logger=ACCESS_LOGGER),
+    ):
+        resp = await _get(client, url)
+    assert resp.status == 200
+    assert not records_for(caplog, DEBUG_LOGGER)
+    assert not records_for(caplog, ACCESS_LOGGER)
+
+
+@pytest.mark.asyncio
+async def test_connection_error(
+    client: Client | SyncClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    url = f"http://localhost:{port}/echo"
+    with (
+        caplog.at_level(logging.DEBUG, logger=DEBUG_LOGGER),
+        caplog.at_level(logging.DEBUG, logger=ACCESS_LOGGER),
+        pytest.raises(ConnectionError),
+    ):
+        await _get(client, url)
+
+    # No response was received so nothing is access logged, matching httpx.
+    assert not records_for(caplog, ACCESS_LOGGER)
+    records = records_for(caplog, DEBUG_LOGGER)
+    assert len(records) == 2
+    assert records[0].getMessage() == f"Sending HTTP request: GET {url}"
+    assert records[1].getMessage().startswith(f"HTTP request failed: GET {url} (")


### PR DESCRIPTION
Adds stdlib `logging` integration emitted directly from the Rust HTTP transports, riding the existing `Instrumentation`/`Operation` lifecycle rather than a middleware. Two DEBUG-only loggers are used: `pyqwest.access` emits one httpx-format `HTTP Request: %s %s "%s %d %s"` summary line per request once response headers arrive, and `pyqwest` emits granular lifecycle records (request sent, and request failed for errors without a response, which are never access-logged). Unlike httpx nothing is logged at INFO, so enabling INFO app-wide does not log every request; as a dotted child, `pyqwest.access` is included when `pyqwest` is set to DEBUG via standard inheritance, with no duplicated records, while an explicit level on it always takes precedence. Both `isEnabledFor(DEBUG)` checks happen per request through cached bound methods in `Constants`, keeping the disabled path near-zero cost and respecting runtime logging config changes. Includes tests covering both clients, streaming, status/version formatting, inheritance and override semantics, and connection errors, plus a Logging section in the usage docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)