### PR TITLE
Map timeouts and connect errors to httpx exceptions in the httpx transports

### DIFF
--- a/pyqwest/__init__.py
+++ b/pyqwest/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = [
     "Client",
+    "ConnectTimeout",
     "FullResponse",
     "HTTPHeaderName",
     "HTTPTransport",
@@ -30,7 +31,7 @@ __all__ = [
 
 from . import _pyqwest
 from ._coro import Client, Response
-from ._errors import StreamError, StreamErrorCode
+from ._errors import ConnectTimeout, StreamError, StreamErrorCode
 from ._multipart import Multipart, Part, SyncMultipart, SyncPart
 from ._pyqwest import (
     FullResponse,

--- a/pyqwest/_errors.py
+++ b/pyqwest/_errors.py
@@ -27,6 +27,14 @@ class StreamErrorCode(IntEnum):
         return cls.INTERNAL_ERROR
 
 
+class ConnectTimeout(ConnectionError, TimeoutError):
+    """An error indicating a timeout while establishing a connection.
+
+    Subclasses both ConnectionError and TimeoutError, so it can be handled
+    as either.
+    """
+
+
 class StreamError(Exception):
     """An error representing an HTTP/2+ stream error."""
 

--- a/pyqwest/_errors.py
+++ b/pyqwest/_errors.py
@@ -28,11 +28,7 @@ class StreamErrorCode(IntEnum):
 
 
 class ConnectTimeout(ConnectionError, TimeoutError):
-    """An error indicating a timeout while establishing a connection.
-
-    Subclasses both ConnectionError and TimeoutError, so it can be handled
-    as either.
-    """
+    """An error indicating a timeout while establishing a connection."""
 
 
 class StreamError(Exception):

--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -64,6 +64,8 @@ class AsyncPyqwestTransport(httpx.AsyncBaseTransport):
             )
         except StreamError as e:
             raise map_stream_error(e) from e
+        except (TimeoutError, asyncio.TimeoutError) as e:
+            raise map_timeout_error(e, request) from e
 
         def get_trailers() -> httpx.Headers:
             return httpx.Headers(tuple(response.trailers.items()))
@@ -133,6 +135,8 @@ class AsyncIteratorByteStream(httpx.AsyncByteStream):
                     yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except (TimeoutError, asyncio.TimeoutError) as e:
+            raise map_timeout_error(e) from e
 
     async def aclose(self) -> None:
         await self._response.aclose()
@@ -175,6 +179,8 @@ class PyqwestTransport(httpx.BaseTransport):
             )
         except StreamError as e:
             raise map_stream_error(e) from e
+        except TimeoutError as e:
+            raise map_timeout_error(e, request) from e
         finally:
             if timeout_manager is not None:
                 timeout_manager.__exit__(None, None, None)
@@ -229,6 +235,8 @@ class IteratorByteStream(httpx.SyncByteStream):
                 yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except TimeoutError as e:
+            raise map_timeout_error(e) from e
 
     def close(self) -> None:
         self._response.close()
@@ -276,6 +284,15 @@ def remaining_time(deadline: float | None) -> float | None:
     if deadline is None:
         return None
     return max(deadline - asyncio.get_running_loop().time(), 0.0)
+
+
+def map_timeout_error(
+    e: BaseException, request: httpx.Request | None = None
+) -> httpx.ReadTimeout:
+    # The operation timeout covers connect/read/write without distinguishing
+    # which phase expired, so all timeouts map to ReadTimeout to satisfy the
+    # httpx.TimeoutException contract.
+    return httpx.ReadTimeout(str(e) or "timed out", request=request)
 
 
 def map_stream_error(e: StreamError) -> httpx.RemoteProtocolError:

--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -64,6 +64,8 @@ class AsyncPyqwestTransport(httpx.AsyncBaseTransport):
             )
         except StreamError as e:
             raise map_stream_error(e) from e
+        except ConnectionError as e:
+            raise map_connection_error(e, request) from e
         except (TimeoutError, asyncio.TimeoutError) as e:
             raise map_timeout_error(e, request) from e
 
@@ -179,6 +181,8 @@ class PyqwestTransport(httpx.BaseTransport):
             )
         except StreamError as e:
             raise map_stream_error(e) from e
+        except ConnectionError as e:
+            raise map_connection_error(e, request) from e
         except TimeoutError as e:
             raise map_timeout_error(e, request) from e
         finally:
@@ -286,12 +290,21 @@ def remaining_time(deadline: float | None) -> float | None:
     return max(deadline - asyncio.get_running_loop().time(), 0.0)
 
 
+def map_connection_error(
+    e: ConnectionError, request: httpx.Request | None = None
+) -> httpx.ConnectError | httpx.ConnectTimeout:
+    if isinstance(e, TimeoutError):
+        return httpx.ConnectTimeout(str(e) or "timed out", request=request)
+    return httpx.ConnectError(str(e), request=request)
+
+
 def map_timeout_error(
     e: BaseException, request: httpx.Request | None = None
 ) -> httpx.ReadTimeout:
-    # The operation timeout covers connect/read/write without distinguishing
-    # which phase expired, so all timeouts map to ReadTimeout to satisfy the
-    # httpx.TimeoutException contract.
+    # Connect timeouts are raised as ConnectTimeout (a ConnectionError) and
+    # mapped by map_connection_error. The remaining operation timeout covers
+    # read/write without distinguishing which phase expired, so it maps to
+    # ReadTimeout to satisfy the httpx.TimeoutException contract.
     return httpx.ReadTimeout(str(e) or "timed out", request=request)
 
 

--- a/src/pyerrors.rs
+++ b/src/pyerrors.rs
@@ -6,6 +6,7 @@ use pyo3::{
 
 create_exception!(pyqwest, ReadError, PyException);
 create_exception!(pyqwest, WriteError, PyException);
+import_exception!(pyqwest._errors, ConnectTimeout);
 import_exception!(pyqwest._errors, StreamError);
 
 pub fn from_reqwest(e: &reqwest::Error, msg: &str) -> PyErr {
@@ -18,7 +19,11 @@ pub fn from_reqwest(e: &reqwest::Error, msg: &str) -> PyErr {
 
     let msg = format!("{msg}: {:+}", errors::fmt(e));
     if e.is_connect() {
-        PyConnectionError::new_err(msg)
+        if e.is_timeout() {
+            ConnectTimeout::new_err(msg)
+        } else {
+            PyConnectionError::new_err(msg)
+        }
     } else if e.is_timeout() {
         PyTimeoutError::new_err(msg)
     } else if e.is_request() {

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
 import threading
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
-from pyqwest import HTTPTransport, SyncHTTPTransport
+from pyqwest import ConnectTimeout, HTTPTransport, SyncHTTPTransport
 from pyqwest.httpx import AsyncPyqwestTransport, PyqwestTransport
 from pyqwest.testing import ASGITransport, WSGITransport
 
@@ -249,6 +250,73 @@ def test_sync_timeout() -> None:
             client.get("http://localhost/")
     finally:
         release.set()
+
+
+def refused_url() -> str:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return f"http://127.0.0.1:{s.getsockname()[1]}/"
+
+
+# A non-routable address, so connection attempts hang until timeout.
+BLACKHOLE_HOST = "10.255.255.1"
+BLACKHOLE_URL = f"http://{BLACKHOLE_HOST}:81/"
+
+
+def require_blackhole() -> None:
+    with socket.socket() as probe:
+        probe.settimeout(0.5)
+        try:
+            probe.connect((BLACKHOLE_HOST, 81))
+        except TimeoutError:
+            return
+        except OSError:
+            pass
+    pytest.skip(f"network does not blackhole {BLACKHOLE_HOST}")
+
+
+@pytest.mark.asyncio
+async def test_async_connect_error() -> None:
+    async with HTTPTransport() as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.ConnectError) as excinfo:
+                await client.get(refused_url())
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+
+
+@pytest.mark.asyncio
+async def test_async_connect_timeout() -> None:
+    require_blackhole()
+    async with HTTPTransport(connect_timeout=0.2) as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.ConnectTimeout) as excinfo:
+                await client.get(BLACKHOLE_URL)
+    assert isinstance(excinfo.value.__cause__, ConnectTimeout)
+
+
+def test_sync_connect_error() -> None:
+    with SyncHTTPTransport() as pyqwest_transport:
+        transport = PyqwestTransport(pyqwest_transport)
+        with (
+            httpx.Client(transport=transport) as client,
+            pytest.raises(httpx.ConnectError) as excinfo,
+        ):
+            client.get(refused_url())
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+
+
+def test_sync_connect_timeout() -> None:
+    require_blackhole()
+    with SyncHTTPTransport(connect_timeout=0.2) as pyqwest_transport:
+        transport = PyqwestTransport(pyqwest_transport)
+        with (
+            httpx.Client(transport=transport) as client,
+            pytest.raises(httpx.ConnectTimeout) as excinfo,
+        ):
+            client.get(BLACKHOLE_URL)
+    assert isinstance(excinfo.value.__cause__, ConnectTimeout)
 
 
 def access_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -156,7 +156,7 @@ async def test_async_timeout_headers() -> None:
     transport = AsyncPyqwestTransport(ASGITransport(app))
     try:
         async with httpx.AsyncClient(transport=transport, timeout=0.1) as client:
-            with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            with pytest.raises(httpx.ReadTimeout):
                 await client.get("http://localhost/")
     finally:
         release.set()
@@ -195,7 +195,7 @@ async def test_async_timeout_response_content() -> None:
         ):
             assert res.status_code == 200
             content = b""
-            with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            with pytest.raises(httpx.ReadTimeout):
                 async for chunk in res.aiter_raw():
                     content += chunk
             assert content == b"partial"
@@ -244,7 +244,7 @@ def test_sync_timeout() -> None:
     try:
         with (
             httpx.Client(transport=transport, timeout=0.1) as client,
-            pytest.raises(TimeoutError),
+            pytest.raises(httpx.ReadTimeout),
         ):
             client.get("http://localhost/")
     finally:


### PR DESCRIPTION
Timeouts and connect failures escaped the httpx adapter as builtin `TimeoutError`/`ConnectionError` — from `asyncio.wait_for` in the async paths and from the Rust layer in the sync/body-read paths — so `except httpx.TimeoutException:`/`except httpx.TransportError:` handlers in user code never fired. This adds a `pyqwest.ConnectTimeout` exception (subclassing both `ConnectionError` and `TimeoutError`), raised when a reqwest connect error is also a timeout, so the connect phase is distinguishable without message sniffing. The httpx transports now map `ConnectTimeout` → `httpx.ConnectTimeout`, other `ConnectionError` → `httpx.ConnectError`, and remaining timeouts → `httpx.ReadTimeout` (the operation timeout collapses read/write, so the expired phase cannot be distinguished further), each with the original exception as `__cause__` and the request attached. Tests cover all four remaps in both sync and async clients, using a blackhole address (with a skip-probe) for connect timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)