### PR TITLE
Implement __iter__ on asyncio awaitables for Python < 3.12

### DIFF
--- a/src/asyncio/awaitable.rs
+++ b/src/asyncio/awaitable.rs
@@ -14,8 +14,6 @@ impl EmptyAwaitable {
         slf
     }
 
-    // Python < 3.12 wraps awaitables with `yield from`, which requires the
-    // result of `__await__` to also implement `__iter__`, not just `__next__`.
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }

--- a/src/asyncio/awaitable.rs
+++ b/src/asyncio/awaitable.rs
@@ -14,6 +14,12 @@ impl EmptyAwaitable {
         slf
     }
 
+    // Python < 3.12 wraps awaitables with `yield from`, which requires the
+    // result of `__await__` to also implement `__iter__`, not just `__next__`.
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
     #[allow(clippy::unused_self)]
     fn __next__(&self) -> Option<()> {
         None
@@ -29,6 +35,10 @@ pub(super) struct ValueAwaitable {
 #[pymethods]
 impl ValueAwaitable {
     fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
 
@@ -51,6 +61,10 @@ pub(super) struct ErrorAwaitable {
 #[pymethods]
 impl ErrorAwaitable {
     fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from pyqwest import FullResponse, Headers, HTTPVersion, Response, SyncResponse
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncIterator, Awaitable, Generator, Iterator
 
 
 @pytest.mark.asyncio
@@ -96,6 +97,39 @@ def test_sync_response_content_iterator():
     for chunk in response.content:
         parts.append(chunk)
     assert parts == [b"Part 1, ", b"Part 2."]
+
+
+def yield_from_await(awaitable: Awaitable[Any]) -> Generator[Any, None, Any]:
+    # Awaits like asyncio.ensure_future on Python < 3.12, which requires the
+    # result of __await__ to be iterable, not just an iterator as plain await.
+    return (yield from awaitable.__await__())
+
+
+def test_response_content_awaitable_supports_yield_from():
+    content = Response(status=200, content=b"Sample body").content
+    with pytest.raises(StopIteration) as exc_info:
+        yield_from_await(content.__anext__()).send(None)
+    assert bytes(exc_info.value.value) == b"Sample body"
+    with pytest.raises(StopAsyncIteration):
+        yield_from_await(content.__anext__()).send(None)
+
+
+def test_response_empty_content_awaitable_supports_yield_from():
+    content = Response(status=200).content
+    with pytest.raises(StopAsyncIteration):
+        yield_from_await(content.__anext__()).send(None)
+
+
+def test_response_aclose_awaitable_supports_yield_from():
+    response = Response(status=200)
+    with pytest.raises(StopIteration):
+        yield_from_await(response.aclose()).send(None)
+
+
+@pytest.mark.asyncio
+async def test_response_content_awaitable_ensure_future():
+    content = Response(status=200, content=b"Sample body").content
+    assert bytes(await asyncio.ensure_future(content.__anext__())) == b"Sample body"
 
 
 def test_full_response_decode_utf8_no_content_type():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -100,8 +100,8 @@ def test_sync_response_content_iterator():
 
 
 def yield_from_await(awaitable: Awaitable[Any]) -> Generator[Any, None, Any]:
-    # Awaits like asyncio.ensure_future on Python < 3.12, which requires the
-    # result of __await__ to be iterable, not just an iterator as plain await.
+    # Python < 3.12 use yield from on an awaitable's iterator in methods like
+    # ensure_future, we test compatibility with that pattern.
     return (yield from awaitable.__await__())
 
 


### PR DESCRIPTION
The hand-rolled awaitables in `src/asyncio/awaitable.rs` (`EmptyAwaitable`, `ValueAwaitable`, `ErrorAwaitable`) implement `__await__`/`__next__` but not `__iter__`. Plain `await` only requires the iterator protocol's `tp_iternext` slot, but `asyncio.ensure_future`/`asyncio.wait_for` on Python < 3.12 wrap awaitables with `yield from awaitable.__await__()`, which requires `__iter__` — so e.g. wrapping a Python-constructed `Response`'s content read in `asyncio.wait_for` raises `TypeError: '_pyqwest.async.ErrorAwaitable' object is not iterable` on 3.10/3.11 (Python 3.12+ rewrote `wait_for` to await directly). Surfaced by CI on #204, which hits this path via the httpx transport's deadline handling. Fixed by implementing `__iter__` (returning self) on all three awaitables, with regression tests that exercise the `yield from` path on all Python versions (verified to fail before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)