### PR TITLE
Map remaining transport errors to httpx exceptions

### DIFF
--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -379,10 +379,6 @@ def map_value_error(
 def map_network_error(
     e: ReadError | WriteError, request: httpx.Request | None = None
 ) -> httpx.ReadError | httpx.WriteError:
-    # pyqwest distinguishes failures while sending the request from failures
-    # while receiving the response, which lines up with the httpx pair. Both
-    # cover transport-level breakage such as a connection reset, so they must
-    # not escape as pyqwest types.
     if isinstance(e, WriteError):
         return httpx.WriteError(str(e), request=request)
     return httpx.ReadError(str(e), request=request)

--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -10,6 +10,7 @@ from h2.events import StreamReset
 
 from pyqwest import (
     Headers,
+    ReadError,
     Request,
     Response,
     StreamError,
@@ -19,6 +20,7 @@ from pyqwest import (
     SyncTransport,
     TooManyRedirects,
     Transport,
+    WriteError,
 )
 from pyqwest._pyqwest import set_sync_timeout
 
@@ -48,24 +50,25 @@ class AsyncPyqwestTransport(httpx.AsyncBaseTransport):
         self._transport = transport
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        request_headers = convert_headers(request)
-        request_content = async_request_content(request.stream)
+        check_scheme(request)
         timeout = convert_timeout(request.extensions)
         deadline = None
         if timeout is not None:
             deadline = asyncio.get_running_loop().time() + timeout
 
         try:
+            pyqwest_request = Request(
+                request.method,
+                str(request.url),
+                headers=convert_headers(request),
+                content=async_request_content(request.stream),
+            )
+        except ValueError as e:
+            raise map_value_error(e, request) from e
+
+        try:
             response = await asyncio.wait_for(
-                self._transport.execute(
-                    Request(
-                        request.method,
-                        str(request.url),
-                        headers=request_headers,
-                        content=request_content,
-                    )
-                ),
-                remaining_time(deadline),
+                self._transport.execute(pyqwest_request), remaining_time(deadline)
             )
         except StreamError as e:
             raise map_stream_error(e) from e
@@ -75,6 +78,8 @@ class AsyncPyqwestTransport(httpx.AsyncBaseTransport):
             raise map_connection_error(e, request) from e
         except (TimeoutError, asyncio.TimeoutError) as e:
             raise map_timeout_error(e, request) from e
+        except (ReadError, WriteError) as e:
+            raise map_network_error(e, request) from e
 
         def get_trailers() -> httpx.Headers:
             return httpx.Headers(tuple(response.trailers.items()))
@@ -144,8 +149,12 @@ class AsyncIteratorByteStream(httpx.AsyncByteStream):
                     yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except ConnectionError as e:
+            raise map_connection_error(e) from e
         except (TimeoutError, asyncio.TimeoutError) as e:
             raise map_timeout_error(e) from e
+        except (ReadError, WriteError) as e:
+            raise map_network_error(e) from e
 
     async def aclose(self) -> None:
         await self._response.aclose()
@@ -173,23 +182,26 @@ class PyqwestTransport(httpx.BaseTransport):
         self._transport = transport
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        request_headers = convert_headers(request)
-        request_content = sync_request_content(request.stream)
+        check_scheme(request)
         timeout = convert_timeout(request.extensions)
+
+        try:
+            pyqwest_request = SyncRequest(
+                request.method,
+                str(request.url),
+                headers=convert_headers(request),
+                content=sync_request_content(request.stream),
+            )
+        except ValueError as e:
+            raise map_value_error(e, request) from e
+
         timeout_manager = None
         if timeout is not None:
             timeout_manager = set_sync_timeout(timeout)
             timeout_manager.__enter__()
 
         try:
-            response = self._transport.execute_sync(
-                SyncRequest(
-                    request.method,
-                    str(request.url),
-                    headers=request_headers,
-                    content=request_content,
-                )
-            )
+            response = self._transport.execute_sync(pyqwest_request)
         except StreamError as e:
             raise map_stream_error(e) from e
         except TooManyRedirects as e:
@@ -198,6 +210,8 @@ class PyqwestTransport(httpx.BaseTransport):
             raise map_connection_error(e, request) from e
         except TimeoutError as e:
             raise map_timeout_error(e, request) from e
+        except (ReadError, WriteError) as e:
+            raise map_network_error(e, request) from e
         finally:
             if timeout_manager is not None:
                 timeout_manager.__exit__(None, None, None)
@@ -252,8 +266,12 @@ class IteratorByteStream(httpx.SyncByteStream):
                 yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except ConnectionError as e:
+            raise map_connection_error(e) from e
         except TimeoutError as e:
             raise map_timeout_error(e) from e
+        except (ReadError, WriteError) as e:
+            raise map_network_error(e) from e
 
     def close(self) -> None:
         self._response.close()
@@ -288,6 +306,20 @@ def convert_headers(request: httpx.Request) -> Headers:
             continue
         headers.add(name, value)
     return headers
+
+
+def check_scheme(request: httpx.Request) -> None:
+    # The transport only speaks HTTP, and the underlying client reports anything
+    # else as a generic client build failure, so reject it here with the same
+    # error httpx uses.
+    scheme = request.url.scheme
+    if scheme not in ("http", "https"):
+        msg = (
+            f"Request URL has an unsupported protocol '{scheme}://'."
+            if scheme
+            else "Request URL is missing an 'http://' or 'https://' protocol."
+        )
+        raise httpx.UnsupportedProtocol(msg, request=request)
 
 
 def convert_timeout(extensions: dict) -> float | None:
@@ -334,6 +366,26 @@ def map_timeout_error(
     # read/write without distinguishing which phase expired, so it maps to
     # ReadTimeout to satisfy the httpx.TimeoutException contract.
     return httpx.ReadTimeout(str(e) or "timed out", request=request)
+
+
+def map_value_error(
+    e: ValueError, request: httpx.Request | None = None
+) -> httpx.LocalProtocolError:
+    # The method, URL or headers were rejected while building the request, so
+    # nothing was sent. httpx reports malformed requests as LocalProtocolError.
+    return httpx.LocalProtocolError(str(e), request=request)
+
+
+def map_network_error(
+    e: ReadError | WriteError, request: httpx.Request | None = None
+) -> httpx.ReadError | httpx.WriteError:
+    # pyqwest distinguishes failures while sending the request from failures
+    # while receiving the response, which lines up with the httpx pair. Both
+    # cover transport-level breakage such as a connection reset, so they must
+    # not escape as pyqwest types.
+    if isinstance(e, WriteError):
+        return httpx.WriteError(str(e), request=request)
+    return httpx.ReadError(str(e), request=request)
 
 
 def map_stream_error(e: StreamError) -> httpx.RemoteProtocolError:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -577,9 +577,11 @@ async def test_async_response_reset() -> None:
         async with HTTPTransport() as pyqwest_transport:
             transport = AsyncPyqwestTransport(pyqwest_transport)
             async with httpx.AsyncClient(transport=transport) as client:
-                with pytest.raises(httpx.ReadError) as excinfo:
+                # Usually a read error but timing can make it a write error
+                # especially on Windows.
+                with pytest.raises((httpx.ReadError, httpx.WriteError)) as excinfo:
                     await client.get(url)
-    assert isinstance(excinfo.value.__cause__, ReadError)
+    assert isinstance(excinfo.value.__cause__, (ReadError, WriteError))
 
 
 @pytest.mark.asyncio
@@ -592,10 +594,12 @@ async def test_sync_response_reset() -> None:
             transport = PyqwestTransport(pyqwest_transport)
             with (
                 httpx.Client(transport=transport) as client,
-                pytest.raises(httpx.ReadError) as excinfo,
+                # Usually a read error but timing can make it a write error
+                # especially on Windows.
+                pytest.raises((httpx.ReadError, httpx.WriteError)) as excinfo,
             ):
                 client.get(url)
-        assert isinstance(excinfo.value.__cause__, ReadError)
+        assert isinstance(excinfo.value.__cause__, (ReadError, WriteError))
 
     await asyncio.to_thread(run)
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import socket
+import struct
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import httpx
 import pytest
@@ -13,12 +15,14 @@ from pyqwest import (
     ConnectTimeout,
     Headers,
     HTTPTransport,
+    ReadError,
     Request,
     Response,
     SyncHTTPTransport,
     SyncRequest,
     SyncResponse,
     Transport,
+    WriteError,
 )
 from pyqwest.httpx import AsyncPyqwestTransport, PyqwestTransport
 from pyqwest.httpx._transport import convert_headers
@@ -26,7 +30,7 @@ from pyqwest.testing import ASGITransport, WSGITransport
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import AsyncIterator, Iterable
+    from collections.abc import AsyncIterator, Iterable, Iterator
 
     from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
@@ -535,3 +539,152 @@ async def test_sync_access_log(url: str, caplog: pytest.LogCaptureFixture) -> No
     records = access_records(caplog)
     assert len(records) == 1
     assert records[0].getMessage() == f'HTTP Request: GET {url}/echo "HTTP/1.1 200 OK"'
+
+
+@contextlib.contextmanager
+def resetting_server(response: bytes) -> Iterator[str]:
+    """Serves `response`, then resets the connection instead of closing it."""
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def serve() -> None:
+        with listener, contextlib.closing(listener.accept()[0]) as conn:
+            conn.recv(65536)
+            conn.sendall(response)
+            # SO_LINGER with a zero timeout makes close() send RST rather than
+            # FIN, so the peer sees a connection reset.
+            conn.setsockopt(
+                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+            )
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/"
+    finally:
+        thread.join(timeout=5)
+
+
+# Promises more body than is sent, so the reset truncates the response.
+TRUNCATED_RESPONSE = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial"
+
+
+@pytest.mark.asyncio
+async def test_async_response_reset() -> None:
+    with resetting_server(TRUNCATED_RESPONSE) as url:
+        async with HTTPTransport() as pyqwest_transport:
+            transport = AsyncPyqwestTransport(pyqwest_transport)
+            async with httpx.AsyncClient(transport=transport) as client:
+                with pytest.raises(httpx.ReadError) as excinfo:
+                    await client.get(url)
+    assert isinstance(excinfo.value.__cause__, ReadError)
+
+
+@pytest.mark.asyncio
+async def test_sync_response_reset() -> None:
+    def run() -> None:
+        with (
+            resetting_server(TRUNCATED_RESPONSE) as url,
+            SyncHTTPTransport() as pyqwest_transport,
+        ):
+            transport = PyqwestTransport(pyqwest_transport)
+            with (
+                httpx.Client(transport=transport) as client,
+                pytest.raises(httpx.ReadError) as excinfo,
+            ):
+                client.get(url)
+        assert isinstance(excinfo.value.__cause__, ReadError)
+
+    await asyncio.to_thread(run)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_scheme", ["http"], indirect=True)
+@pytest.mark.parametrize("http_version", ["h1"], indirect=True)
+async def test_async_request_body_error(url: str) -> None:
+    async def content() -> AsyncIterator[bytes]:
+        yield cast("bytes", 10)
+
+    async with HTTPTransport() as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            # Can surface on either side depending on timing.
+            with pytest.raises((httpx.WriteError, httpx.ReadError)) as excinfo:
+                await client.post(f"{url}/echo", content=content())
+    assert isinstance(excinfo.value.__cause__, (WriteError, ReadError))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_scheme", ["http"], indirect=True)
+@pytest.mark.parametrize("http_version", ["h1"], indirect=True)
+async def test_sync_request_body_error(url: str) -> None:
+    def content() -> Iterator[bytes]:
+        yield cast("bytes", 10)
+
+    def run() -> None:
+        with SyncHTTPTransport() as pyqwest_transport:
+            transport = PyqwestTransport(pyqwest_transport)
+            with (
+                httpx.Client(transport=transport) as client,
+                pytest.raises((httpx.WriteError, httpx.ReadError)) as excinfo,
+            ):
+                client.post(f"{url}/echo", content=content())
+        assert isinstance(excinfo.value.__cause__, (WriteError, ReadError))
+
+    await asyncio.to_thread(run)
+
+
+@pytest.mark.asyncio
+async def test_async_unsupported_scheme() -> None:
+    async with HTTPTransport() as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.UnsupportedProtocol):
+                await client.get("ftp://127.0.0.1:1/")
+
+
+@pytest.mark.asyncio
+async def test_sync_unsupported_scheme() -> None:
+    def run() -> None:
+        with SyncHTTPTransport() as pyqwest_transport:
+            transport = PyqwestTransport(pyqwest_transport)
+            with (
+                httpx.Client(transport=transport) as client,
+                pytest.raises(httpx.UnsupportedProtocol),
+            ):
+                client.get("ftp://127.0.0.1:1/")
+
+    await asyncio.to_thread(run)
+
+
+@pytest.mark.asyncio
+async def test_async_malformed_request() -> None:
+    url = refused_url()
+    async with HTTPTransport() as pyqwest_transport:
+        transport = AsyncPyqwestTransport(pyqwest_transport)
+        async with httpx.AsyncClient(transport=transport) as client:
+            # Rejected while building the request, so nothing is ever sent and
+            # the refused port is never connected to.
+            with pytest.raises(httpx.LocalProtocolError) as excinfo:
+                await client.get(url, headers={"bad name": "value"})
+            assert isinstance(excinfo.value.__cause__, ValueError)
+            with pytest.raises(httpx.LocalProtocolError):
+                await client.request("BAD METHOD", url)
+
+
+@pytest.mark.asyncio
+async def test_sync_malformed_request() -> None:
+    def run() -> None:
+        url = refused_url()
+        with SyncHTTPTransport() as pyqwest_transport:
+            transport = PyqwestTransport(pyqwest_transport)
+            with httpx.Client(transport=transport) as client:
+                with pytest.raises(httpx.LocalProtocolError) as excinfo:
+                    client.get(url, headers={"bad name": "value"})
+                assert isinstance(excinfo.value.__cause__, ValueError)
+                with pytest.raises(httpx.LocalProtocolError):
+                    client.request("BAD METHOD", url)
+
+    await asyncio.to_thread(run)


### PR DESCRIPTION
The httpx transports only remapped timeouts, connect failures, redirects and HTTP/2 stream errors. Everything else escaped as a pyqwest or builtin type, so callers writing ordinary httpx code did not catch it. A connection reset while sending a request, for instance, surfaced as:

```
pyqwest.WriteError: Request failed: error sending request for url (...): client error (SendRequest): connection error: connection reset
```

`pyqwest.ReadError` and `pyqwest.WriteError` are created off `PyException` (`src/pyerrors.rs`), so the existing `except ConnectionError` clause never matched them and no other clause did either. Code catching `httpx.TransportError` or `httpx.HTTPError` — which is what `httpx.AsyncHTTPTransport` teaches you to catch — saw nothing.

### Changes

- `pyqwest.ReadError` maps to `httpx.ReadError` and `pyqwest.WriteError` to `httpx.WriteError` (both `httpx.NetworkError`). Applied at all four sites: `handle_async_request`, `handle_request`, and both response byte streams.
- Both byte streams were also missing a `ConnectionError` handler entirely; added.
- Requests rejected while being built raise `httpx.LocalProtocolError` rather than `ValueError`. Covers invalid header names, invalid header values and invalid methods.
- A non-HTTP request scheme raises `httpx.UnsupportedProtocol` rather than the `RuntimeError` that the underlying client build failure produced.
- Building the request now happens before the sync timeout context is entered, so the deadline covers sending rather than header conversion.

### Verification

Each mapping was checked against `httpx.AsyncHTTPTransport` on the same fault, so the transport reports what httpx's own transport reports. Eight tests added: a raw socket server that truncates a response and then resets via `SO_LINGER` (async and sync), a request body that yields a non-bytes chunk (async and sync), unsupported scheme, and malformed requests.

All four regression tests fail with the raw pyqwest exceptions when the `_transport.py` change is reverted.

Known gaps left for a follow-up, since they need error classification on the Rust side: HTTP framing and parse failures (malformed status line, server disconnecting before a response, bad chunked framing) still surface as `WriteError`/`ReadError` where httpx raises `RemoteProtocolError`, and body decode failures surface as `ReadError` rather than `DecodingError` because reqwest wraps decoder errors in `Kind::Body`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)