### PR TITLE
Map HTTP protocol errors to RemoteProtocolError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
  "mime",
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ h3 = "0.0.8"
 http = "1.4.2"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
+# Only used to classify reqwest's errors; must track the version reqwest depends on.
+hyper = { version = "1.10.1", features = ["client", "http1"] }
 mime = "0.3.17"
 pyo3 = { version = "0.29.0", features = ["bytes"] }
 pyo3-async-runtimes = {

--- a/pyqwest/__init__.py
+++ b/pyqwest/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "Part",
     "Proxy",
     "ReadError",
+    "RemoteProtocolError",
     "Request",
     "Response",
     "StreamError",
@@ -32,7 +33,7 @@ __all__ = [
 
 from . import _pyqwest
 from ._coro import Client, Response
-from ._errors import ConnectTimeout, StreamError, StreamErrorCode
+from ._errors import ConnectTimeout, RemoteProtocolError, StreamError, StreamErrorCode
 from ._multipart import Multipart, Part, SyncMultipart, SyncPart
 from ._pyqwest import (
     FullResponse,

--- a/pyqwest/_coro.py
+++ b/pyqwest/_coro.py
@@ -55,6 +55,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -79,6 +80,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -103,6 +105,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -125,6 +128,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -147,6 +151,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -171,6 +176,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -197,6 +203,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -225,6 +232,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -254,6 +262,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """

--- a/pyqwest/_errors.py
+++ b/pyqwest/_errors.py
@@ -31,7 +31,11 @@ class ConnectTimeout(ConnectionError, TimeoutError):
     """An error indicating a timeout while establishing a connection."""
 
 
-class StreamError(Exception):
+class RemoteProtocolError(Exception):
+    """An error indicating the peer violated the HTTP protocol."""
+
+
+class StreamError(RemoteProtocolError):
     """An error representing an HTTP/2+ stream error."""
 
     code: StreamErrorCode

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -259,6 +259,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -283,6 +284,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -303,6 +305,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -324,6 +327,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -345,6 +349,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -369,6 +374,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -393,6 +399,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -419,6 +426,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -445,6 +453,7 @@ class Client:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -602,6 +611,7 @@ class HTTPTransport:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -696,6 +706,9 @@ class Response:
             headers: The response headers.
             content: The response content.
             trailers: The response trailers.
+
+        Raises:
+            RemoteProtocolError: If the status is not a valid HTTP status code.
         """
 
     def __aenter__(self) -> Awaitable[Response]:
@@ -780,6 +793,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -806,6 +820,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -829,6 +844,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -852,6 +868,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -875,6 +892,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -901,6 +919,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -927,6 +946,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -955,6 +975,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -983,6 +1004,7 @@ class SyncClient:
         Raises:
             ConnectionError: If the connection fails.
             TimeoutError: If the request times out.
+            RemoteProtocolError: If the peer violates the HTTP protocol.
             ReadError: If an error occurs reading the response.
             WriteError: If an error occurs writing the request.
         """
@@ -1193,6 +1215,9 @@ class SyncResponse:
             headers: The response headers.
             content: The response content.
             trailers: The response trailers.
+
+        Raises:
+            RemoteProtocolError: If the status is not a valid HTTP status code.
         """
 
     def __enter__(self) -> SyncResponse:

--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -11,6 +11,7 @@ from h2.events import StreamReset
 from pyqwest import (
     Headers,
     ReadError,
+    RemoteProtocolError,
     Request,
     Response,
     StreamError,
@@ -71,7 +72,11 @@ class AsyncPyqwestTransport(httpx.AsyncBaseTransport):
                 self._transport.execute(pyqwest_request), remaining_time(deadline)
             )
         except StreamError as e:
+            # Must precede RemoteProtocolError, which it subclasses, to keep the
+            # richer stream error message.
             raise map_stream_error(e) from e
+        except RemoteProtocolError as e:
+            raise map_remote_protocol_error(e, request) from e
         except TooManyRedirects as e:
             raise httpx.TooManyRedirects(str(e), request=request) from e
         except ConnectionError as e:
@@ -149,6 +154,8 @@ class AsyncIteratorByteStream(httpx.AsyncByteStream):
                     yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except RemoteProtocolError as e:
+            raise map_remote_protocol_error(e) from e
         except ConnectionError as e:
             raise map_connection_error(e) from e
         except (TimeoutError, asyncio.TimeoutError) as e:
@@ -203,7 +210,11 @@ class PyqwestTransport(httpx.BaseTransport):
         try:
             response = self._transport.execute_sync(pyqwest_request)
         except StreamError as e:
+            # Must precede RemoteProtocolError, which it subclasses, to keep the
+            # richer stream error message.
             raise map_stream_error(e) from e
+        except RemoteProtocolError as e:
+            raise map_remote_protocol_error(e, request) from e
         except TooManyRedirects as e:
             raise httpx.TooManyRedirects(str(e), request=request) from e
         except ConnectionError as e:
@@ -266,6 +277,8 @@ class IteratorByteStream(httpx.SyncByteStream):
                 yield bytes(chunk)
         except StreamError as e:
             raise map_stream_error(e) from e
+        except RemoteProtocolError as e:
+            raise map_remote_protocol_error(e) from e
         except ConnectionError as e:
             raise map_connection_error(e) from e
         except TimeoutError as e:
@@ -382,6 +395,13 @@ def map_network_error(
     if isinstance(e, WriteError):
         return httpx.WriteError(str(e), request=request)
     return httpx.ReadError(str(e), request=request)
+
+
+def map_remote_protocol_error(
+    e: RemoteProtocolError, request: httpx.Request | None = None
+) -> httpx.RemoteProtocolError:
+    # The peer sent something that isn't valid HTTP, or cut a message short.
+    return httpx.RemoteProtocolError(str(e), request=request)
 
 
 def map_stream_error(e: StreamError) -> httpx.RemoteProtocolError:

--- a/pyqwest/httpx/_transport.py
+++ b/pyqwest/httpx/_transport.py
@@ -153,6 +153,8 @@ class AsyncIteratorByteStream(httpx.AsyncByteStream):
                         break
                     yield bytes(chunk)
         except StreamError as e:
+            # Must precede RemoteProtocolError, which it subclasses, to keep the
+            # richer stream error message.
             raise map_stream_error(e) from e
         except RemoteProtocolError as e:
             raise map_remote_protocol_error(e) from e
@@ -276,6 +278,8 @@ class IteratorByteStream(httpx.SyncByteStream):
             for chunk in self._response.content:
                 yield bytes(chunk)
         except StreamError as e:
+            # Must precede RemoteProtocolError, which it subclasses, to keep the
+            # richer stream error message.
             raise map_stream_error(e) from e
         except RemoteProtocolError as e:
             raise map_remote_protocol_error(e) from e

--- a/src/pyerrors.rs
+++ b/src/pyerrors.rs
@@ -8,6 +8,7 @@ create_exception!(pyqwest, ReadError, PyException);
 create_exception!(pyqwest, WriteError, PyException);
 create_exception!(pyqwest, TooManyRedirects, PyException);
 import_exception!(pyqwest._errors, ConnectTimeout);
+import_exception!(pyqwest._errors, RemoteProtocolError);
 import_exception!(pyqwest._errors, StreamError);
 
 pub fn from_reqwest(e: &reqwest::Error, msg: &str) -> PyErr {
@@ -27,6 +28,8 @@ pub fn from_reqwest(e: &reqwest::Error, msg: &str) -> PyErr {
         }
     } else if e.is_timeout() {
         PyTimeoutError::new_err(msg)
+    } else if is_peer_protocol_violation(e) {
+        RemoteProtocolError::new_err(msg)
     } else if e.is_redirect() {
         TooManyRedirects::new_err(msg)
     } else if e.is_request() {
@@ -36,4 +39,31 @@ pub fn from_reqwest(e: &reqwest::Error, msg: &str) -> PyErr {
     } else {
         PyRuntimeError::new_err(msg)
     }
+}
+
+/// Reports whether the error was caused by the peer violating HTTP framing, as
+/// opposed to the connection breaking or the request body failing. A message cut
+/// short by a clean EOF counts, one cut short by a reset does not.
+fn is_peer_protocol_violation(e: &reqwest::Error) -> bool {
+    let Some(e) = errors::find::<hyper::Error>(e) else {
+        return false;
+    };
+
+    // is_parse covers every response head hyper could not decode, including an
+    // unparseable status code and an oversized head.
+    if e.is_parse() || e.is_incomplete_message() {
+        return true;
+    }
+
+    // hyper has no predicate for a body it could not frame, reporting one as an
+    // io error underneath its body error, so the io error kind is what separates
+    // malformed framing from the connection breaking. Reading the io error out of
+    // the hyper error rather than the whole chain keeps response decoders, which
+    // sit outside hyper and fail with InvalidData on corrupt content, out of this.
+    errors::find::<std::io::Error>(e).is_some_and(|e| {
+        matches!(
+            e.kind(),
+            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::UnexpectedEof
+        )
+    })
 }

--- a/src/shared/response.rs
+++ b/src/shared/response.rs
@@ -5,7 +5,6 @@ use http::response::Parts;
 use http_body::Frame;
 use http_body_util::BodyExt as _;
 use pyo3::{
-    exceptions::PyRuntimeError,
     types::{PyBytes, PyInt},
     Bound, IntoPyObject, Py, PyErr, PyResult, Python,
 };
@@ -14,7 +13,7 @@ use tokio::sync::{watch, Mutex};
 use crate::{
     common::{httpversion::HTTPVersion, FullResponse},
     headers::Headers,
-    pyerrors::{self, ReadError},
+    pyerrors::{self, RemoteProtocolError, ReadError},
     shared::constants::Constants,
 };
 
@@ -49,7 +48,7 @@ impl ResponseHead {
         let headers = Headers::from_option(py, headers)?;
         Ok(ResponseHead {
             status: http::StatusCode::from_u16(status)
-                .map_err(|e| PyRuntimeError::new_err(format!("Invalid status code: {e}")))?,
+                .map_err(|e| RemoteProtocolError::new_err(format!("Invalid status code: {e}")))?,
             version,
             headers,
         })

--- a/src/shared/response.rs
+++ b/src/shared/response.rs
@@ -13,7 +13,7 @@ use tokio::sync::{watch, Mutex};
 use crate::{
     common::{httpversion::HTTPVersion, FullResponse},
     headers::Headers,
-    pyerrors::{self, RemoteProtocolError, ReadError},
+    pyerrors::{self, ReadError, RemoteProtocolError},
     shared::constants::Constants,
 };
 

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,7 +1,68 @@
 from __future__ import annotations
 
+import contextlib
+import socket
+import struct
+import threading
 from collections.abc import Iterator
 from queue import Empty, Queue
+
+
+@contextlib.contextmanager
+def raw_server(response: bytes, *, reset: bool = False) -> Iterator[str]:
+    """Serves `response` verbatim to a single request, then closes the connection.
+
+    Passing `reset` closes with an RST rather than a FIN, which is the
+    difference between a truncated response being a protocol violation and
+    being a broken connection.
+    """
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def serve() -> None:
+        with listener, contextlib.closing(listener.accept()[0]) as conn:
+            conn.recv(65536)
+            conn.sendall(response)
+            if reset:
+                # SO_LINGER with a zero timeout makes close() send RST rather
+                # than FIN, so the peer sees a connection reset.
+                conn.setsockopt(
+                    socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                )
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/"
+    finally:
+        thread.join(timeout=5)
+
+
+# Responses that violate HTTP framing in some way. Each is served by
+# `raw_server`, followed by a clean FIN.
+NO_RESPONSE = b""
+"""The server accepts the request then disconnects without responding."""
+
+MALFORMED_STATUS_LINE = b"HTTP/1.1 boom\r\n\r\n"
+"""The status line names a status that is not a number."""
+
+GARBAGE_RESPONSE = b"this is not http\r\n\r\n"
+"""Not an HTTP response at all."""
+
+BAD_CHUNKED_FRAMING = (
+    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nZZZZ\r\nhello\r\n"
+)
+"""The chunk size is not hexadecimal."""
+
+TRUNCATED_RESPONSE = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial"
+"""Promises more body than is sent, so the close truncates the response."""
+
+TRUNCATED_CHUNKED_RESPONSE = (
+    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n"
+)
+"""Ends without the terminating zero-length chunk."""
 
 
 class SyncRequestBody(Iterator[bytes]):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ from pyqwest import (
     Headers,
     HTTPVersion,
     ReadError,
+    RemoteProtocolError,
     SyncClient,
     WriteError,
 )
@@ -745,8 +746,9 @@ async def test_response_error(
     status = 0
     # There is a race between whether the error is handled on the request
     # or response side, which looks like a connection error when the server
-    # aborts. We match either.
-    with pytest.raises((ReadError, WriteError)):
+    # aborts. We match either. Aborting mid-body also leaves the chunked
+    # response unterminated, which is a protocol violation.
+    with pytest.raises((RemoteProtocolError, ReadError, WriteError)):
         method = "POST"
         url = f"{url}/echo"
         headers = {"x-error-response": "1"}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,23 +3,44 @@ from __future__ import annotations
 import asyncio
 import socket
 import sys
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import pytest
 
-from pyqwest import Client, ReadError, SyncClient, WriteError
+from pyqwest import (
+    Client,
+    HTTPTransport,
+    ReadError,
+    RemoteProtocolError,
+    SyncClient,
+    SyncHTTPTransport,
+    WriteError,
+)
 
-from ._util import SyncRequestBody
+from ._util import (
+    BAD_CHUNKED_FRAMING,
+    GARBAGE_RESPONSE,
+    MALFORMED_STATUS_LINE,
+    NO_RESPONSE,
+    TRUNCATED_CHUNKED_RESPONSE,
+    TRUNCATED_RESPONSE,
+    SyncRequestBody,
+    raw_server,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncIterator, Callable, Iterator
     from queue import Queue
 
+_Test = TypeVar("_Test", bound="Callable[..., object]")
 
-pytestmark = [
-    pytest.mark.parametrize("http_scheme", ["http"], indirect=True),
-    pytest.mark.parametrize("http_version", ["h2"], indirect=True),
-]
+
+# Applied per test rather than as a module-level pytestmark because the protocol
+# error tests at the bottom of this file serve their own raw socket and so do not
+# take the shared server fixtures these parametrize.
+def uses_h2_server(fn: _Test) -> _Test:
+    fn = pytest.mark.parametrize("http_version", ["h2"], indirect=True)(fn)
+    return pytest.mark.parametrize("http_scheme", ["http"], indirect=True)(fn)
 
 
 async def request_body(queue: asyncio.Queue) -> AsyncIterator[bytes]:
@@ -39,6 +60,7 @@ def sync_request_body(queue: Queue) -> Iterator[bytes]:
 
 
 @pytest.mark.asyncio
+@uses_h2_server
 async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
     if sys.version_info < (3, 11):
         pytest.skip("asyncio.timeout requires Python 3.11+")
@@ -71,6 +93,7 @@ async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
 
 
 @pytest.mark.asyncio
+@uses_h2_server
 async def test_response_content_timeout(client: Client | SyncClient, url: str) -> None:
     if sys.version_info < (3, 11):
         pytest.skip("asyncio.timeout requires Python 3.11+")
@@ -102,6 +125,7 @@ async def test_response_content_timeout(client: Client | SyncClient, url: str) -
 
 
 @pytest.mark.asyncio
+@uses_h2_server
 async def test_connection_error(
     client: Client | SyncClient, client_type: str, url: str
 ) -> None:
@@ -126,6 +150,7 @@ async def test_connection_error(
 
 
 @pytest.mark.asyncio
+@uses_h2_server
 async def test_request_not_bytes(client: Client | SyncClient, url: str) -> None:
     method = "POST"
     url = f"{url}/echo"
@@ -148,3 +173,65 @@ async def test_request_not_bytes(client: Client | SyncClient, url: str) -> None:
 
             async with client.stream(method, url, content=request_content()) as resp:
                 await anext(resp.content)
+
+
+# Each of these is a way for the peer to break HTTP framing, and each is served
+# over a raw socket so the fault is exactly what the test names. They are
+# HTTP/1.1 by construction, so unlike the tests above they build their own
+# transport rather than using the parametrized fixtures.
+PROTOCOL_FAULTS = [
+    pytest.param(NO_RESPONSE, id="no-response"),
+    pytest.param(MALFORMED_STATUS_LINE, id="malformed-status-line"),
+    pytest.param(GARBAGE_RESPONSE, id="garbage-response"),
+    pytest.param(BAD_CHUNKED_FRAMING, id="bad-chunked-framing"),
+    pytest.param(TRUNCATED_RESPONSE, id="truncated-body"),
+    pytest.param(TRUNCATED_CHUNKED_RESPONSE, id="truncated-chunked-body"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_async_protocol_error(response: bytes) -> None:
+    with raw_server(response) as url:
+        async with HTTPTransport() as transport:
+            with pytest.raises(RemoteProtocolError):
+                await Client(transport).get(url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_sync_protocol_error(response: bytes) -> None:
+    def run() -> None:
+        with (
+            raw_server(response) as url,
+            SyncHTTPTransport() as transport,
+            pytest.raises(RemoteProtocolError),
+        ):
+            SyncClient(transport).get(url)
+
+    await asyncio.to_thread(run)
+
+
+@pytest.mark.asyncio
+async def test_async_response_reset_is_read_error() -> None:
+    # A response cut short by a reset is a broken connection rather than a
+    # protocol violation, so it must not be swept up by the tests above.
+    with raw_server(TRUNCATED_RESPONSE, reset=True) as url:
+        async with HTTPTransport() as transport:
+            # Usually a read error but timing can make it a write error,
+            # especially on Windows.
+            with pytest.raises((ReadError, WriteError)):
+                await Client(transport).get(url)
+
+
+@pytest.mark.asyncio
+async def test_sync_response_reset_is_read_error() -> None:
+    def run() -> None:
+        with (
+            raw_server(TRUNCATED_RESPONSE, reset=True) as url,
+            SyncHTTPTransport() as transport,
+            pytest.raises((ReadError, WriteError)),
+        ):
+            SyncClient(transport).get(url)
+
+    await asyncio.to_thread(run)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,44 +3,23 @@ from __future__ import annotations
 import asyncio
 import socket
 import sys
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
-from pyqwest import (
-    Client,
-    HTTPTransport,
-    ReadError,
-    RemoteProtocolError,
-    SyncClient,
-    SyncHTTPTransport,
-    WriteError,
-)
+from pyqwest import Client, ReadError, SyncClient, WriteError
 
-from ._util import (
-    BAD_CHUNKED_FRAMING,
-    GARBAGE_RESPONSE,
-    MALFORMED_STATUS_LINE,
-    NO_RESPONSE,
-    TRUNCATED_CHUNKED_RESPONSE,
-    TRUNCATED_RESPONSE,
-    SyncRequestBody,
-    raw_server,
-)
+from ._util import SyncRequestBody
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Iterator
+    from collections.abc import AsyncIterator, Iterator
     from queue import Queue
 
-_Test = TypeVar("_Test", bound="Callable[..., object]")
 
-
-# Applied per test rather than as a module-level pytestmark because the protocol
-# error tests at the bottom of this file serve their own raw socket and so do not
-# take the shared server fixtures these parametrize.
-def uses_h2_server(fn: _Test) -> _Test:
-    fn = pytest.mark.parametrize("http_version", ["h2"], indirect=True)(fn)
-    return pytest.mark.parametrize("http_scheme", ["http"], indirect=True)(fn)
+pytestmark = [
+    pytest.mark.parametrize("http_scheme", ["http"], indirect=True),
+    pytest.mark.parametrize("http_version", ["h2"], indirect=True),
+]
 
 
 async def request_body(queue: asyncio.Queue) -> AsyncIterator[bytes]:
@@ -60,7 +39,6 @@ def sync_request_body(queue: Queue) -> Iterator[bytes]:
 
 
 @pytest.mark.asyncio
-@uses_h2_server
 async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
     if sys.version_info < (3, 11):
         pytest.skip("asyncio.timeout requires Python 3.11+")
@@ -93,7 +71,6 @@ async def test_request_timeout(client: Client | SyncClient, url: str) -> None:
 
 
 @pytest.mark.asyncio
-@uses_h2_server
 async def test_response_content_timeout(client: Client | SyncClient, url: str) -> None:
     if sys.version_info < (3, 11):
         pytest.skip("asyncio.timeout requires Python 3.11+")
@@ -125,7 +102,6 @@ async def test_response_content_timeout(client: Client | SyncClient, url: str) -
 
 
 @pytest.mark.asyncio
-@uses_h2_server
 async def test_connection_error(
     client: Client | SyncClient, client_type: str, url: str
 ) -> None:
@@ -150,7 +126,6 @@ async def test_connection_error(
 
 
 @pytest.mark.asyncio
-@uses_h2_server
 async def test_request_not_bytes(client: Client | SyncClient, url: str) -> None:
     method = "POST"
     url = f"{url}/echo"
@@ -173,65 +148,3 @@ async def test_request_not_bytes(client: Client | SyncClient, url: str) -> None:
 
             async with client.stream(method, url, content=request_content()) as resp:
                 await anext(resp.content)
-
-
-# Each of these is a way for the peer to break HTTP framing, and each is served
-# over a raw socket so the fault is exactly what the test names. They are
-# HTTP/1.1 by construction, so unlike the tests above they build their own
-# transport rather than using the parametrized fixtures.
-PROTOCOL_FAULTS = [
-    pytest.param(NO_RESPONSE, id="no-response"),
-    pytest.param(MALFORMED_STATUS_LINE, id="malformed-status-line"),
-    pytest.param(GARBAGE_RESPONSE, id="garbage-response"),
-    pytest.param(BAD_CHUNKED_FRAMING, id="bad-chunked-framing"),
-    pytest.param(TRUNCATED_RESPONSE, id="truncated-body"),
-    pytest.param(TRUNCATED_CHUNKED_RESPONSE, id="truncated-chunked-body"),
-]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
-async def test_async_protocol_error(response: bytes) -> None:
-    with raw_server(response) as url:
-        async with HTTPTransport() as transport:
-            with pytest.raises(RemoteProtocolError):
-                await Client(transport).get(url)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
-async def test_sync_protocol_error(response: bytes) -> None:
-    def run() -> None:
-        with (
-            raw_server(response) as url,
-            SyncHTTPTransport() as transport,
-            pytest.raises(RemoteProtocolError),
-        ):
-            SyncClient(transport).get(url)
-
-    await asyncio.to_thread(run)
-
-
-@pytest.mark.asyncio
-async def test_async_response_reset_is_read_error() -> None:
-    # A response cut short by a reset is a broken connection rather than a
-    # protocol violation, so it must not be swept up by the tests above.
-    with raw_server(TRUNCATED_RESPONSE, reset=True) as url:
-        async with HTTPTransport() as transport:
-            # Usually a read error but timing can make it a write error,
-            # especially on Windows.
-            with pytest.raises((ReadError, WriteError)):
-                await Client(transport).get(url)
-
-
-@pytest.mark.asyncio
-async def test_sync_response_reset_is_read_error() -> None:
-    def run() -> None:
-        with (
-            raw_server(TRUNCATED_RESPONSE, reset=True) as url,
-            SyncHTTPTransport() as transport,
-            pytest.raises((ReadError, WriteError)),
-        ):
-            SyncClient(transport).get(url)
-
-    await asyncio.to_thread(run)

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 import pytest
+from h2.errors import ErrorCodes
 
 from pyqwest import (
     ConnectTimeout,
@@ -611,9 +612,11 @@ async def test_async_stream_error_keeps_reset_message() -> None:
     async with httpx.AsyncClient(transport=transport) as client:
         with pytest.raises(httpx.RemoteProtocolError) as excinfo:
             await client.get("http://localhost/")
-    # REFUSED_STREAM is code 7; the plain protocol error message has no code.
+    # The plain protocol error message would just be the "boom" above. Compare
+    # against the rendered enum rather than a literal, because IntEnum.__str__
+    # gives the name rather than the number before Python 3.11.
     assert "StreamReset" in str(excinfo.value)
-    assert "error_code:7" in str(excinfo.value)
+    assert f"error_code:{ErrorCodes.REFUSED_STREAM!s}" in str(excinfo.value)
 
 
 def test_sync_stream_error_keeps_reset_message() -> None:
@@ -623,9 +626,11 @@ def test_sync_stream_error_keeps_reset_message() -> None:
         pytest.raises(httpx.RemoteProtocolError) as excinfo,
     ):
         client.get("http://localhost/")
-    # REFUSED_STREAM is code 7; the plain protocol error message has no code.
+    # The plain protocol error message would just be the "boom" above. Compare
+    # against the rendered enum rather than a literal, because IntEnum.__str__
+    # gives the name rather than the number before Python 3.11.
     assert "StreamReset" in str(excinfo.value)
-    assert "error_code:7" in str(excinfo.value)
+    assert f"error_code:{ErrorCodes.REFUSED_STREAM!s}" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import socket
-import struct
 import threading
 from typing import TYPE_CHECKING, cast
 
@@ -16,8 +14,11 @@ from pyqwest import (
     Headers,
     HTTPTransport,
     ReadError,
+    RemoteProtocolError,
     Request,
     Response,
+    StreamError,
+    StreamErrorCode,
     SyncHTTPTransport,
     SyncRequest,
     SyncResponse,
@@ -27,6 +28,16 @@ from pyqwest import (
 from pyqwest.httpx import AsyncPyqwestTransport, PyqwestTransport
 from pyqwest.httpx._transport import convert_headers
 from pyqwest.testing import ASGITransport, WSGITransport
+
+from ._util import (
+    BAD_CHUNKED_FRAMING,
+    GARBAGE_RESPONSE,
+    MALFORMED_STATUS_LINE,
+    NO_RESPONSE,
+    TRUNCATED_CHUNKED_RESPONSE,
+    TRUNCATED_RESPONSE,
+    raw_server,
+)
 
 if TYPE_CHECKING:
     import sys
@@ -541,39 +552,87 @@ async def test_sync_access_log(url: str, caplog: pytest.LogCaptureFixture) -> No
     assert records[0].getMessage() == f'HTTP Request: GET {url}/echo "HTTP/1.1 200 OK"'
 
 
-@contextlib.contextmanager
-def resetting_server(response: bytes) -> Iterator[str]:
-    """Serves `response`, then resets the connection instead of closing it."""
-    listener = socket.socket()
-    listener.bind(("127.0.0.1", 0))
-    listener.listen(1)
-    port = listener.getsockname()[1]
-
-    def serve() -> None:
-        with listener, contextlib.closing(listener.accept()[0]) as conn:
-            conn.recv(65536)
-            conn.sendall(response)
-            # SO_LINGER with a zero timeout makes close() send RST rather than
-            # FIN, so the peer sees a connection reset.
-            conn.setsockopt(
-                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
-            )
-
-    thread = threading.Thread(target=serve, daemon=True)
-    thread.start()
-    try:
-        yield f"http://127.0.0.1:{port}/"
-    finally:
-        thread.join(timeout=5)
+# Each of these is a way for the peer to break HTTP framing. httpx reports all of
+# them as RemoteProtocolError, so the transports must too.
+PROTOCOL_FAULTS = [
+    pytest.param(NO_RESPONSE, id="no-response"),
+    pytest.param(MALFORMED_STATUS_LINE, id="malformed-status-line"),
+    pytest.param(GARBAGE_RESPONSE, id="garbage-response"),
+    pytest.param(BAD_CHUNKED_FRAMING, id="bad-chunked-framing"),
+    pytest.param(TRUNCATED_RESPONSE, id="truncated-body"),
+    pytest.param(TRUNCATED_CHUNKED_RESPONSE, id="truncated-chunked-body"),
+]
 
 
-# Promises more body than is sent, so the reset truncates the response.
-TRUNCATED_RESPONSE = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial"
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_async_protocol_error(response: bytes) -> None:
+    with raw_server(response) as url:
+        async with HTTPTransport() as pyqwest_transport:
+            transport = AsyncPyqwestTransport(pyqwest_transport)
+            async with httpx.AsyncClient(transport=transport) as client:
+                with pytest.raises(httpx.RemoteProtocolError) as excinfo:
+                    await client.get(url)
+    assert isinstance(excinfo.value.__cause__, RemoteProtocolError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_sync_protocol_error(response: bytes) -> None:
+    def run() -> None:
+        with raw_server(response) as url, SyncHTTPTransport() as pyqwest_transport:
+            transport = PyqwestTransport(pyqwest_transport)
+            with (
+                httpx.Client(transport=transport) as client,
+                pytest.raises(httpx.RemoteProtocolError) as excinfo,
+            ):
+                client.get(url)
+        assert isinstance(excinfo.value.__cause__, RemoteProtocolError)
+
+    await asyncio.to_thread(run)
+
+
+class StreamErrorTransport(Transport):
+    """Fails every request with an HTTP/2 stream error."""
+
+    async def execute(self, request: Request) -> Response:
+        raise StreamError("boom", StreamErrorCode.REFUSED_STREAM)
+
+    def execute_sync(self, request: SyncRequest) -> SyncResponse:
+        raise StreamError("boom", StreamErrorCode.REFUSED_STREAM)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_error_keeps_reset_message() -> None:
+    # StreamError subclasses RemoteProtocolError, so it has to stay matched first
+    # to keep the stream reset detail rather than falling back to the plain
+    # protocol error message.
+    transport = AsyncPyqwestTransport(StreamErrorTransport())
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(httpx.RemoteProtocolError) as excinfo:
+            await client.get("http://localhost/")
+    # REFUSED_STREAM is code 7; the plain protocol error message has no code.
+    assert "StreamReset" in str(excinfo.value)
+    assert "error_code:7" in str(excinfo.value)
+
+
+def test_sync_stream_error_keeps_reset_message() -> None:
+    transport = PyqwestTransport(StreamErrorTransport())
+    with (
+        httpx.Client(transport=transport) as client,
+        pytest.raises(httpx.RemoteProtocolError) as excinfo,
+    ):
+        client.get("http://localhost/")
+    # REFUSED_STREAM is code 7; the plain protocol error message has no code.
+    assert "StreamReset" in str(excinfo.value)
+    assert "error_code:7" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
 async def test_async_response_reset() -> None:
-    with resetting_server(TRUNCATED_RESPONSE) as url:
+    # A reset breaks the connection rather than the protocol, so unlike the
+    # truncations above it stays a read error, matching httpx.
+    with raw_server(TRUNCATED_RESPONSE, reset=True) as url:
         async with HTTPTransport() as pyqwest_transport:
             transport = AsyncPyqwestTransport(pyqwest_transport)
             async with httpx.AsyncClient(transport=transport) as client:
@@ -588,7 +647,7 @@ async def test_async_response_reset() -> None:
 async def test_sync_response_reset() -> None:
     def run() -> None:
         with (
-            resetting_server(TRUNCATED_RESPONSE) as url,
+            raw_server(TRUNCATED_RESPONSE, reset=True) as url,
             SyncHTTPTransport() as pyqwest_transport,
         ):
             transport = PyqwestTransport(pyqwest_transport)

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -27,6 +27,7 @@ from pyqwest import (
     HTTPTransport,
     HTTPVersion,
     ReadError,
+    RemoteProtocolError,
     StreamError,
     SyncClient,
     SyncHTTPTransport,
@@ -361,7 +362,15 @@ async def test_response_error(
     url = f"{url}/echo"
     headers = [("content-type", "text/plain"), ("x-error-response", "1")]
 
-    with pytest.raises((ReadError, StreamError)) as exc_info:
+    # h2 signals the abort as a stream error, while on h1 it arrives as a
+    # chunked response left unterminated. StreamError subclasses RemoteProtocolError,
+    # but pin it so the h2 path keeps its error code.
+    expected: type[Exception] | tuple[type[Exception], ...] = (
+        StreamError
+        if http_version == HTTPVersion.HTTP2
+        else (RemoteProtocolError, ReadError)
+    )
+    with pytest.raises(expected) as exc_info:
         if isinstance(client, SyncClient):
             await asyncio.to_thread(client.get, url, headers=headers)
         else:

--- a/tests/test_protocol_errors.py
+++ b/tests/test_protocol_errors.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pyqwest import (
+    Client,
+    HTTPTransport,
+    ReadError,
+    RemoteProtocolError,
+    SyncClient,
+    SyncHTTPTransport,
+    WriteError,
+)
+
+from ._util import (
+    BAD_CHUNKED_FRAMING,
+    GARBAGE_RESPONSE,
+    MALFORMED_STATUS_LINE,
+    NO_RESPONSE,
+    TRUNCATED_CHUNKED_RESPONSE,
+    TRUNCATED_RESPONSE,
+    raw_server,
+)
+
+# Each of these is a way for the peer to break HTTP framing, and each is served
+# over a raw socket so the fault is exactly what the test names. They are
+# HTTP/1.1 by construction, so unlike the tests above they build their own
+# transport rather than using the parametrized fixtures.
+PROTOCOL_FAULTS = [
+    pytest.param(NO_RESPONSE, id="no-response"),
+    pytest.param(MALFORMED_STATUS_LINE, id="malformed-status-line"),
+    pytest.param(GARBAGE_RESPONSE, id="garbage-response"),
+    pytest.param(BAD_CHUNKED_FRAMING, id="bad-chunked-framing"),
+    pytest.param(TRUNCATED_RESPONSE, id="truncated-body"),
+    pytest.param(TRUNCATED_CHUNKED_RESPONSE, id="truncated-chunked-body"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_async_protocol_error(response: bytes) -> None:
+    with raw_server(response) as url:
+        async with HTTPTransport() as transport:
+            with pytest.raises(RemoteProtocolError):
+                await Client(transport).get(url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", PROTOCOL_FAULTS)
+async def test_sync_protocol_error(response: bytes) -> None:
+    def run() -> None:
+        with (
+            raw_server(response) as url,
+            SyncHTTPTransport() as transport,
+            pytest.raises(RemoteProtocolError),
+        ):
+            SyncClient(transport).get(url)
+
+    await asyncio.to_thread(run)
+
+
+@pytest.mark.asyncio
+async def test_async_response_reset_is_read_error() -> None:
+    # A response cut short by a reset is a broken connection rather than a
+    # protocol violation, so it must not be swept up by the tests above.
+    with raw_server(TRUNCATED_RESPONSE, reset=True) as url:
+        async with HTTPTransport() as transport:
+            # Usually a read error but timing can make it a write error,
+            # especially on Windows.
+            with pytest.raises((ReadError, WriteError)):
+                await Client(transport).get(url)
+
+
+@pytest.mark.asyncio
+async def test_sync_response_reset_is_read_error() -> None:
+    def run() -> None:
+        with (
+            raw_server(TRUNCATED_RESPONSE, reset=True) as url,
+            SyncHTTPTransport() as transport,
+            pytest.raises((ReadError, WriteError)),
+        ):
+            SyncClient(transport).get(url)
+
+    await asyncio.to_thread(run)


### PR DESCRIPTION
Follow-up to #210, covering the gap it deliberately left: faults where the peer violated HTTP framing (malformed status line, garbage response, bad chunked framing, a message truncated by a clean FIN, and a server disconnecting without responding) surfaced as `ReadError`/`WriteError`, so httpx callers got a network error instead of the `RemoteProtocolError` their retry code catches — the last of those is the common production case, a server closing a pooled keep-alive connection between requests.

reqwest buckets framing failures into its send and read kinds, so the new `pyqwest.RemoteProtocolError` is classified from the hyper error underneath: its parse and incomplete-message predicates cover the response head, and for a body hyper could not frame, the `io::ErrorKind` under its body error — read out of the hyper error rather than the whole chain, so response decoders failing with `InvalidData` on corrupt content keep reporting as read errors, and a response truncated by an RST stays a `ReadError`, both matching httpx.

The name follows httpx, whose own `ProtocolError` is the parent of the local and remote variants and so would have been the same name with a narrower meaning; pyqwest raises `ValueError` for the local case, which the transports already map to `httpx.LocalProtocolError`.

`StreamError` now subclasses it, which is additive, and stays matched first in both httpx transports so h2 keeps its richer stream reset message; `Response(status=...)` with an out-of-range status also moves from `RuntimeError` into this bucket.

Every row is pinned by a test at both the pyqwest and httpx layers over a raw socket server, including regressions that an RST-truncated body is still a `ReadError` and that an h2 stream error still carries its reset code — these also act as the tripwire for the new direct `hyper` dependency, which must track reqwest's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)