### PR TITLE
Raise when tls_ca_cert contains no certificate

### DIFF
--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -545,6 +545,8 @@ class HTTPTransport:
 
         Args:
             tls_ca_cert: The CA certificate to use to verify the server for TLS connections.
+                         PEM-encoded, and may contain multiple certificates. Raises ValueError if
+                         it contains no certificate.
             tls_include_system_certs: Whether to include the system CA certificates to verify TLS connections.
                                       If this is unset and tls_ca_cert is not provided, TLS will not function.
             tls_key: The client private key to identify the client for mTLS connections.
@@ -1060,6 +1062,8 @@ class SyncHTTPTransport:
 
         Args:
             tls_ca_cert: The CA certificate to use to verify the server for TLS connections.
+                         PEM-encoded, and may contain multiple certificates. Raises ValueError if
+                         it contains no certificate.
             tls_include_system_certs: Whether to include the system CA certificates to verify TLS connections.
                                       If this is unset and tls_ca_cert is not provided, TLS will not function.
             tls_key: The client private key to identify the client for mTLS connections.

--- a/pyqwest/_pyqwest.pyi
+++ b/pyqwest/_pyqwest.pyi
@@ -544,9 +544,7 @@ class HTTPTransport:
         When creating a transport, take care to set options to meet your needs.
 
         Args:
-            tls_ca_cert: The CA certificate to use to verify the server for TLS connections.
-                         PEM-encoded, and may contain multiple certificates. Raises ValueError if
-                         it contains no certificate.
+            tls_ca_cert: The PEM-encoded CA certificate(s) to use to verify the server for TLS connections.
             tls_include_system_certs: Whether to include the system CA certificates to verify TLS connections.
                                       If this is unset and tls_ca_cert is not provided, TLS will not function.
             tls_key: The client private key to identify the client for mTLS connections.
@@ -1061,9 +1059,7 @@ class SyncHTTPTransport:
         When creating a transport, take care to set options to meet your needs.
 
         Args:
-            tls_ca_cert: The CA certificate to use to verify the server for TLS connections.
-                         PEM-encoded, and may contain multiple certificates. Raises ValueError if
-                         it contains no certificate.
+            tls_ca_cert: The PEM-encoded CA certificate(s) to use to verify the server for TLS connections.
             tls_include_system_certs: Whether to include the system CA certificates to verify TLS connections.
                                       If this is unset and tls_ca_cert is not provided, TLS will not function.
             tls_key: The client private key to identify the client for mTLS connections.

--- a/src/shared/transport.rs
+++ b/src/shared/transport.rs
@@ -62,12 +62,19 @@ pub(crate) fn new_reqwest_client(params: ClientParams) -> PyResult<(reqwest::Cli
         }
     }
     if let Some(ca_cert) = params.tls_ca_cert {
-        let cert = reqwest::Certificate::from_pem(ca_cert)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to parse CA certificate: {e}")))?;
+        // from_pem_bundle parses eagerly, unlike from_pem which defers parsing until the client is
+        // built and silently trusts nothing when the input contains no PEM certificate block.
+        let certs = reqwest::Certificate::from_pem_bundle(ca_cert)
+            .map_err(|e| PyValueError::new_err(format!("Failed to parse CA certificate: {e}")))?;
+        if certs.is_empty() {
+            return Err(PyValueError::new_err(
+                "tls_ca_cert did not contain any PEM certificates",
+            ));
+        }
         if params.tls_include_system_certs {
-            builder = builder.tls_certs_merge([cert]);
+            builder = builder.tls_certs_merge(certs);
         } else {
-            builder = builder.tls_certs_only([cert]);
+            builder = builder.tls_certs_only(certs);
         }
     } else if !params.tls_include_system_certs {
         builder = builder.tls_certs_only([]);

--- a/src/shared/transport.rs
+++ b/src/shared/transport.rs
@@ -62,8 +62,6 @@ pub(crate) fn new_reqwest_client(params: ClientParams) -> PyResult<(reqwest::Cli
         }
     }
     if let Some(ca_cert) = params.tls_ca_cert {
-        // from_pem_bundle parses eagerly, unlike from_pem which defers parsing until the client is
-        // built and silently trusts nothing when the input contains no PEM certificate block.
         let certs = reqwest::Certificate::from_pem_bundle(ca_cert)
             .map_err(|e| PyValueError::new_err(format!("Failed to parse CA certificate: {e}")))?;
         if certs.is_empty() {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,51 @@ def test_invalid_client_cert(client_type: str) -> None:
             HTTPTransport(tls_key=b"invalid", tls_cert=b"invalid")
 
 
+@pytest.mark.parametrize(
+    "ca_cert",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"not a pem", id="no-pem-block"),
+        pytest.param(b"\x30\x82\x01\x0a\x02\x82\x01\x01", id="der"),
+        pytest.param(
+            b"-----BEGIN PRIVATE KEY-----\nZm9v\n-----END PRIVATE KEY-----\n", id="key"
+        ),
+    ],
+)
+@pytest.mark.parametrize("include_system_certs", [False, True])
+def test_ca_cert_without_certificates(
+    ca_cert: bytes, include_system_certs: bool, client_type: str
+) -> None:
+    with pytest.raises(ValueError, match="did not contain any PEM certificates"):
+        if client_type == "sync":
+            SyncHTTPTransport(
+                tls_ca_cert=ca_cert, tls_include_system_certs=include_system_certs
+            )
+        else:
+            HTTPTransport(
+                tls_ca_cert=ca_cert, tls_include_system_certs=include_system_certs
+            )
+
+
+def test_unparsable_ca_cert(client_type: str) -> None:
+    ca_cert = b"-----BEGIN CERTIFICATE-----\n!!!!\n-----END CERTIFICATE-----\n"
+    with pytest.raises(ValueError, match="Failed to parse CA certificate"):
+        if client_type == "sync":
+            SyncHTTPTransport(tls_ca_cert=ca_cert)
+        else:
+            HTTPTransport(tls_ca_cert=ca_cert)
+
+
+def test_invalid_ca_cert(client_type: str) -> None:
+    # Valid PEM framing and base64, but the body is not a certificate.
+    ca_cert = b"-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n"
+    with pytest.raises(RuntimeError, match="invalid peer certificate"):
+        if client_type == "sync":
+            SyncHTTPTransport(tls_ca_cert=ca_cert)
+        else:
+            HTTPTransport(tls_ca_cert=ca_cert)
+
+
 def test_only_client_cert(client_type: str) -> None:
     with pytest.raises(ValueError, match="Both tls_key and tls_cert must be provided"):
         if client_type == "sync":


### PR DESCRIPTION
`reqwest::Certificate::from_pem` does not parse its input — it stores the bytes and defers parsing to client build, where the PEM reader skips any section that isn't a `CERTIFICATE`. So `tls_ca_cert` bytes containing no certificate block at all (an empty file, DER, a private key, the wrong file) added no trust anchors and raised nothing, leaving the misconfiguration to surface later as an unspecific `invalid peer certificate` against the one host the CA was configured for.

This switches to `from_pem_bundle`, which parses eagerly and returns the certificates it found, and rejects an empty result with `ValueError: tls_ca_cert did not contain any PEM certificates` on both `HTTPTransport` and `SyncHTTPTransport`. As a side effect, unparsable PEM bodies now fail with `Failed to parse CA certificate` instead of reaching the client builder — that branch was previously unreachable, since `from_pem` only fails with the native-tls backend. Multi-certificate bundles are unaffected; valid base64 that isn't a certificate still surfaces from the builder as `invalid peer certificate: BadEncoding`, because only rustls' `RootCertStore::add` validates DER.

Adds `test_ca_cert_without_certificates` covering four zero-certificate inputs across both `tls_include_system_certs` values and both transports, plus tests for the two malformed-body shapes, and documents the requirement in the type stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)